### PR TITLE
Improve DonateMenu and add more info to contributionMessage

### DIFF
--- a/src/main/java/me/knighthat/apis/menus/MenuEvents.java
+++ b/src/main/java/me/knighthat/apis/menus/MenuEvents.java
@@ -4,6 +4,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryCloseEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 
@@ -25,6 +26,14 @@ public class MenuEvents implements Listener {
             event.setCancelled(true);
             if (event.getCurrentItem() != null)
                 menu.onItemClick(event);
+        }
+    }
+
+    @EventHandler
+    public void inventoryDragEvent(InventoryDragEvent event) {
+        Inventory topInventory = event.getView().getTopInventory();
+        if (topInventory.getHolder() instanceof Menu) {
+            event.setCancelled(true);
         }
     }
 

--- a/src/main/java/me/wonka01/ServerQuests/configuration/QuestModel.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/QuestModel.java
@@ -10,6 +10,7 @@ import org.bukkit.Material;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 public class QuestModel {
@@ -22,7 +23,7 @@ public class QuestModel {
     private final ObjectiveType objective;
     private final List<String> mobNames;
     private final ArrayList<Reward> rewards;
-    private final List<String> itemNames;
+    private final List<Material> itemNames;
     private final Material displayItem;
     private final List<String> worlds;
     private final String questDuration;
@@ -43,7 +44,14 @@ public class QuestModel {
         this.objective = objective;
         this.mobNames = mobNames;
         this.rewards = rewards;
-        this.itemNames = itemNames;
+        this.itemNames = itemNames.stream().map(itemName -> {
+            String capitalizedMaterialName = itemName.toUpperCase().replaceAll(" ", "_");
+            Material material = Material.getMaterial(capitalizedMaterialName);
+            if (material == null) {
+                return Material.AIR;
+            }
+            return material;
+        }).filter(material -> material != Material.AIR).collect(Collectors.toList());
         this.worlds = worlds;
         this.questDuration = questDuration;
         this.rewardLimit = rewardLimit;

--- a/src/main/java/me/wonka01/ServerQuests/events/BreakEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/BreakEvent.java
@@ -1,10 +1,10 @@
 package me.wonka01.ServerQuests.events;
 
-import me.knighthat.apis.utils.Utils;
 import me.wonka01.ServerQuests.ServerQuests;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
+import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -33,9 +33,9 @@ public class BreakEvent extends QuestListener implements Listener {
 
         List<QuestController> controllers = tryGetControllersOfEventType(ObjectiveType.BLOCK_BREAK);
         for (QuestController controller : controllers) {
-            List<String> materials = controller.getEventConstraints().getMaterialNames();
+            List<Material> materials = controller.getEventConstraints().getMaterials();
 
-            if (materials.isEmpty() || Utils.contains(materials, event.getBlock().getType())) {
+            if (materials.isEmpty() || materials.contains(event.getBlock().getType())) {
                 event.getBlock().setMetadata(BROKEN, meta);
                 updateQuest(controller, event.getPlayer(), 1);
                 break;

--- a/src/main/java/me/wonka01/ServerQuests/events/ConsumeItemQuestEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/ConsumeItemQuestEvent.java
@@ -1,9 +1,9 @@
 package me.wonka01.ServerQuests.events;
 
-import me.knighthat.apis.utils.Utils;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -23,9 +23,9 @@ public class ConsumeItemQuestEvent extends QuestListener implements Listener {
 
         List<QuestController> controllers = tryGetControllersOfEventType(ObjectiveType.CONSUME_ITEM);
         for (QuestController controller : controllers) {
-            List<String> materials = controller.getEventConstraints().getMaterialNames();
+            List<Material> materials = controller.getEventConstraints().getMaterials();
 
-            if (materials.isEmpty() || Utils.contains(materials, event.getItem().getType()))
+            if (materials.isEmpty() || materials.contains(event.getItem().getType()))
                 updateQuest(controller, player, 1);
         }
     }

--- a/src/main/java/me/wonka01/ServerQuests/events/CraftItemQuestEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/CraftItemQuestEvent.java
@@ -1,9 +1,9 @@
 package me.wonka01.ServerQuests.events;
 
-import me.knighthat.apis.utils.Utils;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -25,9 +25,9 @@ public class CraftItemQuestEvent extends QuestListener implements Listener {
 
         List<QuestController> controllers = tryGetControllersOfEventType(ObjectiveType.CRAFT_ITEM);
         for (QuestController controller : controllers) {
-            List<String> materials = controller.getEventConstraints().getMaterialNames();
+            List<Material> materials = controller.getEventConstraints().getMaterials();
 
-            if (materials.isEmpty() || Utils.contains(materials, event.getRecipe().getResult().getType()))
+            if (materials.isEmpty() || materials.contains(event.getRecipe().getResult().getType()))
                 updateQuest(controller, player, amount);
         }
     }

--- a/src/main/java/me/wonka01/ServerQuests/events/EnchantItemQuestEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/EnchantItemQuestEvent.java
@@ -1,9 +1,9 @@
 package me.wonka01.ServerQuests.events;
 
-import me.knighthat.apis.utils.Utils;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -21,13 +21,11 @@ public class EnchantItemQuestEvent extends QuestListener implements Listener {
     public void onEnchantItem(EnchantItemEvent event) {
         Player player = event.getEnchanter();
 
-        String materialName = event.getItem().getType().toString();
-
         List<QuestController> controllers = tryGetControllersOfEventType(ObjectiveType.ENCHANT_ITEM);
         for (QuestController controller : controllers) {
-            List<String> materials = controller.getEventConstraints().getMaterialNames();
+            List<Material> materials = controller.getEventConstraints().getMaterials();
 
-            if (materials.isEmpty() || Utils.contains(materials, materialName)) {
+            if (materials.isEmpty() || materials.contains(event.getItem().getType())) {
                 updateQuest(controller, player, 1);
             }
         }

--- a/src/main/java/me/wonka01/ServerQuests/events/GuiEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/GuiEvent.java
@@ -1,9 +1,9 @@
 package me.wonka01.ServerQuests.events;
 
-import me.knighthat.apis.utils.Utils;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
@@ -20,11 +20,11 @@ public class GuiEvent extends QuestListener {
         boolean isItemUsed = false;
         for (QuestController controller : controllers) {
 
-            List<String> materials = controller.getEventConstraints().getMaterialNames();
+            List<Material> materials = controller.getEventConstraints().getMaterials();
             int goal = controller.getQuestData().getQuestGoal();
             int completed = controller.getQuestData().getQuestGoal();
 
-            if (materials.isEmpty() || Utils.contains(materials, itemsToAdd.getType())) {
+            if (materials.isEmpty() || materials.contains(itemsToAdd.getType())) {
                 if (goal > 0 && completed + itemsToAdd.getAmount() > goal) {
                     int difference = completed + itemsToAdd.getAmount() - goal;
                     ItemStack itemsToReturn = new ItemStack(itemsToAdd.getType(), difference);

--- a/src/main/java/me/wonka01/ServerQuests/events/PlaceEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/PlaceEvent.java
@@ -1,10 +1,10 @@
 package me.wonka01.ServerQuests.events;
 
-import me.knighthat.apis.utils.Utils;
 import me.wonka01.ServerQuests.ServerQuests;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -34,8 +34,8 @@ public class PlaceEvent extends QuestListener implements Listener {
 
         List<QuestController> controllers = tryGetControllersOfEventType(ObjectiveType.BLOCK_PLACE);
         for (QuestController controller : controllers) {
-            List<String> materials = controller.getEventConstraints().getMaterialNames();
-            if (materials.isEmpty() || Utils.contains(materials, block.getType())) {
+            List<Material> materials = controller.getEventConstraints().getMaterials();
+            if (materials.isEmpty() || materials.contains(block.getType())) {
                 updateQuest(controller, event.getPlayer(), 1);
                 block.setMetadata(PLACED, meta);
             }

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/EventConstraints.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/EventConstraints.java
@@ -1,17 +1,18 @@
 package me.wonka01.ServerQuests.questcomponents;
 
 import lombok.Getter;
+import org.bukkit.Material;
 
 import java.util.List;
 
 @Getter
 public class EventConstraints {
-    private List<String> materialNames;
-    private List<String> mobNames;
-    private List<String> worlds;
+    private final List<Material> materials;
+    private final List<String> mobNames;
+    private final List<String> worlds;
 
-    public EventConstraints(List<String> materialNames, List<String> mobNames, List<String> worlds) {
-        this.materialNames = materialNames;
+    public EventConstraints(List<Material> materials, List<String> mobNames, List<String> worlds) {
+        this.materials = materials;
         this.mobNames = mobNames;
         this.worlds = worlds;
     }

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestController.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestController.java
@@ -11,6 +11,7 @@ import me.wonka01.ServerQuests.questcomponents.players.BasePlayerComponent;
 import me.wonka01.ServerQuests.questcomponents.schedulers.QuestTimer;
 import org.bukkit.entity.Player;
 
+import java.text.DecimalFormat;
 import java.util.UUID;
 
 @Getter
@@ -52,7 +53,7 @@ public class QuestController implements Colorization {
 
         playerComponent.savePlayerAction(player, amountToAdd);
         updateBossBar();
-        sendPlayerMessage(player);
+        sendPlayerMessage(player, count);
 
         return getQuestData().isGoalComplete();
     }
@@ -87,11 +88,15 @@ public class QuestController implements Colorization {
         questBar.updateBarProgress(barProgress);
     }
 
-    private void sendPlayerMessage(Player player) {
+    private final DecimalFormat decimalFormat = new DecimalFormat("#,###.##");
+    private void sendPlayerMessage(Player player, double count) {
         if (!player.hasPermission("communityquests.showmessages"))
             return;
 
-        String message = color(plugin.messages().message("contributionMessage"));
+        String message = color(
+            plugin.messages().message("contributionMessage", questData)
+                .replaceAll("contributionCount", decimalFormat.format(count))
+        );
         player.sendMessage(message);
     }
 

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -18,7 +18,7 @@ questFailureMessage: "&4&lQUEST FAILED &f( questName &f) \n Unfortunately the qu
 questStartMessage: "&a&lA new server-wide quest has begun &f- questName \n questDescription"
 
 # message sent to player when they contribute if communityquests.showmessages permission is set to true.
-contributionMessage: "&a+1 for the quest questName"
+contributionMessage: "&a+contributionCount for the quest questName"
 
 # This message will proceed the list of top players
 topContributorsTitle: "&l&eTop Contributors&r"


### PR DESCRIPTION
I noticed some clicks weren't being picked up by the /cq donate menu; so I quickly fixed it myself.
While fixing that, I noticed a few more areas for improvement:

Non-donate menu related changes:
- The plugin now blocks drag events from putting items in its menus
- Item names in "materials" are parsed once; instead of on every check
- Added `contributionCount` to `contributionMessage` since `+1` looked awkward

Donate menu related changes:
- Border item is created earlier
- Clicks like shift-click, number key and off-hand swap are now considered as input
- Since we get the clicked item more dynamically now, we can get rid of delaying the quest item check

If you do not want one or more of these changes, don't hesitate to comment on it and I'll remove it.
Feel free to also comment on code style, everyone has their own and I'll respect if you want something to not be different in your repository.