### PR TITLE
Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Opens a GUI to claim rewards for completed quests
 
 Claims rewards for a specific player. Rewards are directly given to the user
 
+### /cq clearrewards <playerName>
+
+Clear all rewards for a specific player. Do not specify a player name if you want to clear rewards for all players.
+
 ## Configuration
 
 The config.yml is used to configure quests in the plugin. Once the quests have been created you can start them using the /cq start command.
@@ -240,6 +244,9 @@ rewards:
                 - material: stone_sword
                     amount: 1
                     displayName: "&8Stone Sword"
+            commands:
+                - 'give %player% diamond_sword 1 0 {display:{Name:"{\"text\":\"Powerful Diamond Sword\",\"color\":\"aqua\"}"},ench:[{id:16,lvl:5}]}'
+
 ```
 
 Old Rewards example (still works will be removed eventually)
@@ -317,6 +324,7 @@ Fishing:
 -   **enchantitem**: enchant something
 -   **money**: players can contribute money with /cq deposit <amount>
 -   **experience**: players must gather Minecraft experience
+-   **carvepumpkin**: use shears on a pumpkin
 -   **mythicmob**: Kill mobs from the mythicmob plugin (requires MythicMobs to be installed)
 
 ### MythicMobs Example
@@ -374,3 +382,4 @@ The questId is the key used in the yml file. In the quest above the id would be 
 -   communityquests.bossbar.hide - if set the user will not see the boss bar.
 -   communityquests.claim - the ability to claim rewards for completed quests (skips the GUI)
 -   communityquests.claim.others - the ability to claim rewards for another player (mainly for OPs so rewards can be claimed with a custom UI)
+-   communityquests.clearrewards - the ability to clear rewards for a player (OP default)

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>me.wonka01</groupId>
     <artifactId>CommunityQuests</artifactId>
-    <version>2.9.1</version>
+    <version>2.10.0</version>
 
     <contributors>
         <contributor>
@@ -32,7 +32,6 @@
     </properties>
 
     <build>
-        <directory>C:/Users/willi/MinecraftServer/plugins</directory>
         <defaultGoal>clean validate deploy</defaultGoal>
         <finalName>${project.name}-${project.version}</finalName>
         <sourceDirectory>src/main/java</sourceDirectory>

--- a/src/main/java/me/knighthat/apis/files/Config.java
+++ b/src/main/java/me/knighthat/apis/files/Config.java
@@ -4,10 +4,14 @@ import lombok.Getter;
 import lombok.NonNull;
 import me.wonka01.ServerQuests.ServerQuests;
 import me.wonka01.ServerQuests.configuration.QuestLibrary;
+import me.wonka01.ServerQuests.gui.DonateMenu;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.bossbar.BarManager;
 import me.wonka01.ServerQuests.questcomponents.players.BasePlayerComponent;
+
+import org.bukkit.Material;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.ItemStack;
 
 @Getter
 public final class Config extends Getters {
@@ -16,7 +20,6 @@ public final class Config extends Getters {
     private final @NonNull ActiveQuests activeQuests = new ActiveQuests();
 
     public Config(ServerQuests plugin) {
-
         super(plugin);
         initializeVariables();
         initializeQuests();
@@ -31,6 +34,12 @@ public final class Config extends Getters {
 
         boolean disableBar = get().getBoolean("disableBossBar", false);
         BarManager.setDisableBossBar(disableBar);
+
+        Material borderMaterial = Material.matchMaterial(get().getString("donateMenuItem", "BLACK_STAINED_GLASS_PANE"));
+        if (borderMaterial == null) {
+            borderMaterial = Material.BLACK_STAINED_GLASS_PANE;
+        }
+        DonateMenu.setBorderItem(new ItemStack(borderMaterial));
     }
 
     public void initializeQuests() {

--- a/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
+++ b/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
@@ -16,7 +16,6 @@ import me.wonka01.placeholders.CommunityQuestsPlaceholders;
 import net.milkbowl.vault.economy.Economy;
 
 import org.bukkit.Bukkit;
-import org.bukkit.entity.Boss;
 import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -61,6 +60,10 @@ public class ServerQuests extends JavaPlugin {
         BossbarPlayerInfo.getInstance().saveToJsonFile(getDataFolder());
         BarManager.closeBar();
         getLogger().info("Plugin is disabled");
+    }
+
+    public @NonNull JsonQuestSave getJsonSave() {
+        return this.jsonSave;
     }
 
     public @NonNull Config config() {

--- a/src/main/java/me/wonka01/ServerQuests/commands/ClearRewardsCommand.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/ClearRewardsCommand.java
@@ -1,0 +1,60 @@
+package me.wonka01.ServerQuests.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import me.wonka01.ServerQuests.ServerQuests;
+import me.wonka01.ServerQuests.questcomponents.rewards.RewardManager;
+
+public class ClearRewardsCommand extends PluginCommand {
+    public ClearRewardsCommand(ServerQuests plugin) {
+        super(plugin, false);
+    }
+
+    @Override
+    public String getName() {
+        return "clearrewards";
+    }
+
+    @Override
+    public String getPermission() {
+        return "communityquests.clearrewards";
+    }
+
+    @Override
+    public void execute(CommandSender sender, String[] args) {
+        if (!sender.hasPermission("communityquests.clearrewards")) {
+            String noPermission = getPlugin().messages().message("noPermission");
+            sender.sendMessage(noPermission);
+            return;
+        }
+
+        if (args.length > 1) {
+            String playerName = args[1];
+            Player target = Bukkit.getPlayer(playerName);
+            if (target != null) {
+                RewardManager rewards = RewardManager.getInstance();
+
+                if (rewards.getRewards(target.getUniqueId()).isEmpty()) {
+                    String noRewards = getPlugin().messages().message("noRewards");
+                    sender.sendMessage(noRewards);
+                    return;
+                }
+
+                rewards.removeRewards(target.getUniqueId());
+                String rewardsCleared = getPlugin().messages().message("rewardsCleared");
+                sender.sendMessage(rewardsCleared);
+            } else {
+                String playerNotFound = getPlugin().messages().message("playerNotFound");
+                sender.sendMessage(playerNotFound);
+            }
+            return;
+        } else if (sender instanceof Player) {
+            RewardManager.getInstance().clearRewards();
+            String rewardsCleared = getPlugin().messages().message("rewardsCleared");
+            sender.sendMessage(rewardsCleared);
+        }
+    }
+
+}

--- a/src/main/java/me/wonka01/ServerQuests/commands/CommandManager.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/CommandManager.java
@@ -35,6 +35,7 @@ public class CommandManager implements CommandExecutor {
         commands.add(new RewardsCommand(plugin));
         commands.add(new EndAllCommand(plugin));
         commands.add(new ClaimRewards(plugin));
+        commands.add(new ClearRewardsCommand(plugin));
     }
 
     @Override

--- a/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
@@ -47,6 +47,7 @@ public class JsonQuestSave {
         } else {
             try {
                 path.createNewFile();
+                saveQuestsInProgress();
             } catch (IOException e) {
                 Bukkit.getServer().getConsoleSender().sendMessage(e.getMessage());
             }
@@ -121,7 +122,8 @@ public class JsonQuestSave {
                     JSONArray materials = (JSONArray) obj.get("materials");
                     JSONArray customNames = (JSONArray) obj.get("customMobNames");
                     List<Material> materialList = convertJsonArrayToList(materials).stream().map(materialName -> {
-                        Material material = Material.getMaterial(materialName);
+                        String capitalizedMaterialName = materialName.toUpperCase().replaceAll(" ", "_");
+                        Material material = Material.getMaterial(capitalizedMaterialName);
                         if (material == null) {
                             return Material.AIR;
                         }

--- a/src/main/java/me/wonka01/ServerQuests/enums/ObjectiveType.java
+++ b/src/main/java/me/wonka01/ServerQuests/enums/ObjectiveType.java
@@ -23,6 +23,7 @@ public enum ObjectiveType {
     EXPERIENCE("experience", Material.EXPERIENCE_BOTTLE),
     HARVEST("harvest", Material.WHEAT),
     MYTHIC_MOB("mythicmob", Material.DRAGON_EGG),
+    CARVE_PUMPKIN("carvepumpkin", Material.CARVED_PUMPKIN),
     UNKNOWN("unknown", Material.AIR);
 
     @Getter

--- a/src/main/java/me/wonka01/ServerQuests/events/BreakEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/BreakEvent.java
@@ -10,6 +10,7 @@ import org.bukkit.block.data.Ageable;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.EventPriority;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -28,7 +29,7 @@ public class BreakEvent extends QuestListener implements Listener {
                 .getBoolean("disableDuplicateBreaks");
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onBlockBreakEvent(BlockBreakEvent event) {
         if (disableDuplicateBreaks && event.getBlock().hasMetadata(BROKEN)) {
             return;

--- a/src/main/java/me/wonka01/ServerQuests/events/CatchFishEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/CatchFishEvent.java
@@ -1,9 +1,6 @@
 package me.wonka01.ServerQuests.events;
 
-import me.knighthat.apis.utils.Utils;
-import me.wonka01.ServerQuests.enums.ObjectiveType;
-import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
-import me.wonka01.ServerQuests.questcomponents.QuestController;
+import java.util.List;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Item;
@@ -11,7 +8,9 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerFishEvent;
 
-import java.util.List;
+import me.wonka01.ServerQuests.enums.ObjectiveType;
+import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
+import me.wonka01.ServerQuests.questcomponents.QuestController;
 
 public class CatchFishEvent extends QuestListener implements Listener {
 

--- a/src/main/java/me/wonka01/ServerQuests/events/ConsumeItemQuestEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/ConsumeItemQuestEvent.java
@@ -5,6 +5,7 @@ import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerItemConsumeEvent;
 
@@ -16,7 +17,7 @@ public class ConsumeItemQuestEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onConsumeItem(PlayerItemConsumeEvent event) {
         Player player = event.getPlayer();
 

--- a/src/main/java/me/wonka01/ServerQuests/events/CraftItemQuestEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/CraftItemQuestEvent.java
@@ -8,6 +8,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.CraftItemEvent;
@@ -22,9 +23,13 @@ public class CraftItemQuestEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onCraftItem(CraftItemEvent event) {
         ItemStack craftedItem = event.getInventory().getResult(); // Get result of recipe
+        if (craftedItem == null) {
+            return;
+        }
+
         Inventory Inventory = event.getInventory(); // Get crafting inventory
         ClickType clickType = event.getClick();
         Material material = craftedItem.getType();

--- a/src/main/java/me/wonka01/ServerQuests/events/EnchantItemQuestEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/EnchantItemQuestEvent.java
@@ -3,9 +3,9 @@ package me.wonka01.ServerQuests.events;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.enchantment.EnchantItemEvent;
 
@@ -17,7 +17,7 @@ public class EnchantItemQuestEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onEnchantItem(EnchantItemEvent event) {
         Player player = event.getEnchanter();
 

--- a/src/main/java/me/wonka01/ServerQuests/events/ExperienceEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/ExperienceEvent.java
@@ -4,6 +4,7 @@ import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerExpChangeEvent;
 
@@ -15,7 +16,7 @@ public class ExperienceEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onExperienceEvent(PlayerExpChangeEvent event) {
         List<QuestController> controllers = tryGetControllersOfObjectiveType(ObjectiveType.EXPERIENCE);
         for (QuestController controller : controllers) {

--- a/src/main/java/me/wonka01/ServerQuests/events/HarvestEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/HarvestEvent.java
@@ -1,15 +1,16 @@
 package me.wonka01.ServerQuests.events;
 
-import me.wonka01.ServerQuests.enums.ObjectiveType;
-import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
-import me.wonka01.ServerQuests.questcomponents.QuestController;
-import org.bukkit.Material;
+import java.util.List;
+
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerHarvestBlockEvent;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.List;
+import me.wonka01.ServerQuests.enums.ObjectiveType;
+import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
+import me.wonka01.ServerQuests.questcomponents.QuestController;
 
 public class HarvestEvent extends QuestListener implements Listener {
 
@@ -17,11 +18,10 @@ public class HarvestEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onHarvestEvent(PlayerHarvestBlockEvent event) {
         List<QuestController> controllers = tryGetControllersOfObjectiveType(ObjectiveType.HARVEST);
         for (QuestController controller : controllers) {
-
             List<ItemStack> harvestedItems = event.getItemsHarvested();
             for (ItemStack item : harvestedItems) {
                 updateQuest(controller, event.getPlayer(), item.getAmount(), ObjectiveType.HARVEST, item.getType());

--- a/src/main/java/me/wonka01/ServerQuests/events/KillPlayerEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/KillPlayerEvent.java
@@ -5,6 +5,7 @@ import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 
@@ -16,7 +17,7 @@ public class KillPlayerEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onKillPlayer(PlayerDeathEvent event) {
 
         Player killer = event.getEntity().getKiller();

--- a/src/main/java/me/wonka01/ServerQuests/events/MilkCowEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/MilkCowEvent.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Cow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 
@@ -19,7 +20,7 @@ public class MilkCowEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerMilkCow(PlayerInteractEntityEvent event) {
         Player player = event.getPlayer();
         Entity cow = event.getRightClicked();

--- a/src/main/java/me/wonka01/ServerQuests/events/MobKillEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/MobKillEvent.java
@@ -7,6 +7,7 @@ import me.wonka01.ServerQuests.questcomponents.QuestController;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDeathEvent;
 
@@ -18,7 +19,7 @@ public class MobKillEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void OnPlayerKillMob(EntityDeathEvent event) {
 
         LivingEntity entity = event.getEntity();

--- a/src/main/java/me/wonka01/ServerQuests/events/MythicMobKillEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/MythicMobKillEvent.java
@@ -1,18 +1,16 @@
 package me.wonka01.ServerQuests.events;
 
-import me.wonka01.ServerQuests.enums.ObjectiveType;
-import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
-import me.wonka01.ServerQuests.questcomponents.QuestController;
+import java.util.List;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 
 import io.lumine.mythic.bukkit.events.MythicMobDeathEvent;
-
-import java.util.List;
+import me.wonka01.ServerQuests.enums.ObjectiveType;
+import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
+import me.wonka01.ServerQuests.questcomponents.QuestController;
 
 public class MythicMobKillEvent extends QuestListener implements Listener {
 

--- a/src/main/java/me/wonka01/ServerQuests/events/PlaceEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/PlaceEvent.java
@@ -4,8 +4,8 @@ import me.wonka01.ServerQuests.ServerQuests;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
+import org.bukkit.event.EventPriority;
 
-import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -28,7 +28,7 @@ public class PlaceEvent extends QuestListener implements Listener {
                 .getBoolean("disableDuplicatePlaces");
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onBlockPlace(BlockPlaceEvent event) {
         Block block = event.getBlock();
         if (disableDuplicatePlaces && block.hasMetadata(PLACED)) {

--- a/src/main/java/me/wonka01/ServerQuests/events/ProjectileKillEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/ProjectileKillEvent.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
@@ -20,7 +21,7 @@ public class ProjectileKillEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onProjectileKill(EntityDeathEvent event) {
         if (!(event.getEntity().getLastDamageCause() instanceof EntityDamageByEntityEvent)) {
             return;

--- a/src/main/java/me/wonka01/ServerQuests/events/QuestListener.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/QuestListener.java
@@ -7,7 +7,6 @@ import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
 import me.wonka01.ServerQuests.questcomponents.QuestData;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 

--- a/src/main/java/me/wonka01/ServerQuests/events/ShearEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/ShearEvent.java
@@ -4,8 +4,14 @@ import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
 
 import java.util.List;
 
@@ -15,11 +21,35 @@ public class ShearEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onSheer(PlayerShearEntityEvent shearEvent) {
         List<QuestController> controllers = tryGetControllersOfObjectiveType(ObjectiveType.SHEAR);
         for (QuestController controller : controllers) {
             updateQuest(controller, shearEvent.getPlayer(), 1, ObjectiveType.SHEAR);
         }
     }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerUseShearsOnPumpkin(PlayerInteractEvent event) {
+        if (event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+            return;
+        }
+
+        Block block = event.getClickedBlock();
+
+        if (block == null || block.getType() != Material.PUMPKIN) {
+            return;
+        }
+
+        ItemStack itemInHand = event.getItem();
+        if (itemInHand == null || itemInHand.getType() != Material.SHEARS) {
+            return;
+        }
+
+        List<QuestController> controllers = tryGetControllersOfObjectiveType(ObjectiveType.CARVE_PUMPKIN);
+        for (QuestController controller : controllers) {
+            updateQuest(controller, event.getPlayer(), 1, ObjectiveType.CARVE_PUMPKIN);
+        }
+    }
+
 }

--- a/src/main/java/me/wonka01/ServerQuests/events/TameEvent.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/TameEvent.java
@@ -5,6 +5,7 @@ import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityTameEvent;
 
@@ -15,7 +16,7 @@ public class TameEvent extends QuestListener implements Listener {
         super(activeQuests);
     }
 
-    @EventHandler
+    @EventHandler(priority = EventPriority.MONITOR)
     public void onTameEvent(EntityTameEvent tameEvent) {
         if (tameEvent.getOwner() instanceof Player) {
             List<QuestController> controllers = tryGetControllersOfObjectiveType(ObjectiveType.TAME);

--- a/src/main/java/me/wonka01/ServerQuests/gui/DonateMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/DonateMenu.java
@@ -2,10 +2,10 @@ package me.wonka01.ServerQuests.gui;
 
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import me.knighthat.apis.menus.Menu;
 import me.knighthat.apis.utils.Utils;
 import me.wonka01.ServerQuests.ServerQuests;
-import me.wonka01.ServerQuests.enums.EventType;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.objectives.Objective;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
@@ -31,17 +31,12 @@ public class DonateMenu extends Menu {
 
     @Getter
     private final int inputSlot = 22;
-    private final ItemStack borderItem;
+    @Getter
+    @Setter
+    private static ItemStack borderItem = new ItemStack(Material.BLACK_STAINED_GLASS_PANE);
 
     public DonateMenu(ServerQuests plugin, @NonNull Player owner) {
         super(plugin, owner, "donateMenu", 45);
-
-        Material borderMaterial = Material.getMaterial(
-                getPlugin().getConfig().getString("donateMenuItem", "BLACK_STAINED_GLASS_PANE"));
-        if (borderMaterial == null) {
-            borderMaterial = Material.BLACK_STAINED_GLASS_PANE;
-        }
-        borderItem = createItemStack(borderMaterial, " ");
     }
 
     @Override

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestController.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestController.java
@@ -78,6 +78,11 @@ public class QuestController implements Colorization {
         playerComponent.savePlayerAction(player, amountToAdd, objectiveId);
         updateBossBar();
         sendPlayerMessage(player, amountToAdd);
+
+        if (questData.getAmountCompleted() % 100 == 0) {
+            plugin.getJsonSave().saveQuestsInProgress();
+        }
+
         if (getQuestData().isGoalComplete()) {
             endQuest();
         }

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestTypeHandler.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestTypeHandler.java
@@ -9,7 +9,6 @@ import me.wonka01.ServerQuests.questcomponents.bossbar.QuestBar;
 import me.wonka01.ServerQuests.questcomponents.players.BasePlayerComponent;
 import me.wonka01.ServerQuests.questcomponents.players.PlayerData;
 
-import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.Nullable;
 

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
@@ -2,13 +2,11 @@ package me.wonka01.ServerQuests.questcomponents.bossbar;
 
 import lombok.NonNull;
 import me.knighthat.apis.utils.Colorization;
-import me.wonka01.ServerQuests.ServerQuests;
 import org.bukkit.Bukkit;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.boss.BossBar;
 import org.bukkit.entity.Player;
-import org.bukkit.plugin.java.JavaPlugin;
 
 public class QuestBar implements Colorization {
 

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/players/SortByContributions.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/players/SortByContributions.java
@@ -12,6 +12,12 @@ public class SortByContributions implements Comparator<UUID> {
     }
 
     public int compare(UUID p1Id, UUID p2Id) {
-        return (int) map.get(p2Id).getAmountContributed() - (int) map.get(p1Id).getAmountContributed();
+        int contributionComparison = Double.compare(map.get(p2Id).getAmountContributed(),
+                map.get(p1Id).getAmountContributed());
+
+        if (contributionComparison == 0) {
+            return p1Id.compareTo(p2Id);
+        }
+        return contributionComparison;
     }
 }

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/rewards/MoneyReward.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/rewards/MoneyReward.java
@@ -5,7 +5,6 @@ import me.knighthat.apis.utils.Colorization;
 import me.wonka01.ServerQuests.ServerQuests;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.json.simple.JSONObject;
 

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/rewards/RewardManager.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/rewards/RewardManager.java
@@ -52,6 +52,10 @@ public class RewardManager {
         }
     }
 
+    public void clearRewards() {
+        playerRewards.clear();
+    }
+
     public boolean hasRewards(UUID playerId) {
         return playerRewards.containsKey(playerId) && playerRewards.get(playerId).size() > 0;
     }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -30,6 +30,8 @@ noRewards: "&cYou have no rewards to claim."
 cantDonateItem: "&cThe given item does not have an active donation quest"
 droppedReward: "&cInventory is full! Reward was dropped on the ground."
 playerNotOnline: "&cThe player is not online"
+rewardsCleared: "&aAll rewards have been cleared"
+playerNotFound: "&cThe player could not be found"
 
 # Single words
 experience: "&eexperience"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -41,7 +41,7 @@ permissions:
         default: true
     communityquests.showmessages:
         description: If true the player will receive a message when they contribute to the quest
-        default: op
+        default: false
     communityquests.togglebar:
         description: Allows player to use the toggle boss bar command to show/hide boss bar for quests
         default: true
@@ -50,4 +50,7 @@ permissions:
         default: true
     communityquests.claim.other:
         description: Claim rewards for others
+        default: op
+    communityquests.clearrewards:
+        description: Clear rewards from all quests
         default: op


### PR DESCRIPTION
- new carvepumpkin event to celebrate Halloween! 
- new /cq clearrewards command to clear all rewards
- fixed event priorities for better compatibility with other plugins that disable certain events like protecting blocks and disabling certain crafts.
- making quest save file more resilient in case of errors (will make a more robust solution in the future)
- fixed an issue were some events needed to be written in ALL CAPS. For example carrots and CARROTS will both work for blockbreak events.
- Fixed issue where /cq reload wasn't updating the donate menu display item 
- showmessages permission is now disabled by default for everyone so the +1 messages don't come up for ops since some dude on spigot got annoyed by it 