### PR TITLE
Holograms, leaderboard improvements and scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ The questId is the key used in the yml file. In the quest above the id would be 
 -   `%communityquests_top_rank_contribution_questId%`: similar to the command above for the player's contribution
 -   `%communityquests_progressbar_questId%` - a progress bar showing the current progress of the quest
 -   `%communityquests_rank_you_questId%` - your rank in the quest
+-   `%communityquests_top_all_questId%` - Displays a leaderboard of the top players in the quest using /n newlines to separate the players. Works well with the hologram!
 
 ## Permissions
 
@@ -462,18 +463,18 @@ Schedule quests to automatically start at specific times with configurable recur
 Basic command structure:
 
 ```
-/cq schedulequests <questId> <coop|comp> <time> <DAILY|WEEKLY|CUSTOM_DAYS> <add|remove> [day|interval]
+/cq schedule <questId> <coop|comp> <time> <DAILY|WEEKLY|CUSTOM_DAYS> <add|remove> [day|interval]
 ```
 
 ### Examples:
 
--   Daily Quest: `/cq schedulequests mining coop 14:30 DAILY add`  
+-   Daily Quest: `/cq schedule mining coop 14:30 DAILY add`  
     Starts the "mining" quest every day at 2:30 PM
--   Weekly Quest: `/cq schedulequests fishing coop 09:00 WEEKLY add MONDAY`  
+-   Weekly Quest: `/cq schedule fishing coop 09:00 WEEKLY add MONDAY`  
     Starts the "fishing" quest every Monday at 9:00 AM
--   Custom Interval: `/cq schedulequests boss comp 20:00 CUSTOM_DAYS add 3`  
+-   Custom Interval: `/cq schedule boss comp 20:00 CUSTOM_DAYS add 3`  
     Starts the "boss" quest every 3 days at 8:00 PM
--   Remove Schedule: `/cq schedulequests any coop 00:00 DAILY remove <scheduleId>`  
+-   Remove Schedule: `/cq schedule any coop 00:00 DAILY remove <scheduleId>`  
     Removes the schedule with the given ID
 
 ### Manual Configuration (schedules.yml)

--- a/README.md
+++ b/README.md
@@ -115,9 +115,17 @@ for available materials.
 
 ### description (required)
 
-A short description of the quest used in messages and displays.
+A short description of the quest used in messages and displays. You can use the \n character to create a new line in your description.
 
-### objectives (required)
+### barColor (optional)
+
+The color of the boss bar that will be displayed for the quest. The color can be one of the following: PINK, BLUE, RED, GREEN, YELLOW, PURPLE, WHITE. If no color is set the boss bar will be white.
+
+### barStyle (optional)
+
+The style of the boss bar that will be displayed for the quest. The style can be one of the following: SOLID, SEGMENTED_6, SEGMENTED_10, SEGMENTED_12, SEGMENTED_20. If no style is set the bar will be solid.
+
+## Objectives (required)
 
 The objectives are the tasks that need to be completed to finish the quest. Each quest can have multiple objectives. The type of objective is required and the goal is required unless questDuration is set on the entire quest. The description is optional but recommended.
 
@@ -178,23 +186,6 @@ Pass in a command to be run if a quest fails, this will only be run if a quest h
 
 Use this parameter to restrict quests to specific worlds. All worlds in the list will be able to participate in quests. When no value
 is provided for worlds then the quest will be enabled in every world.
-
-### materials (DEPRECATED use objectives instead)
-
-Optional parameter for the following quest types:
-blockbreak, blockplace, donate, enchantitem, craftitem and consumeitem. If the field is empty or nonexistent then all blocks will be considered.
-
-### entities (DEPRECATED use objectives instead)
-
-Optional field for the following quest types: mobkill, projectilekill and catchfish. If empty or not used, all mob types will be included.
-
-### type (DEPRECATED use objectives instead)
-
-The quest type, see here for a list of types:
-
-### goal (DEPRECATED use objectives instead)
-
-The amount you'll need to complete to finish the quest. To run a collaborative quest a goal is required even if you have a questDuration set.
 
 ### disableDuplicateBreaks
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 -   [Rewards](#Rewards)
 -   [Quest Types](#Objectives)
 -   [Placeholders](#Placeholders)
+-   [Holograms](#Holograms)
+-   [Quest Scheduler](#Quest-Scheduler)
 
 ## Summary
 
@@ -161,6 +163,21 @@ objectives:
       description: Zombie Pigmen
 ```
 
+### dynamic objectives
+
+You can use placeholders to create dynamic goal for an objective! For example the quest below is based on the number of players online when the quest starts. Use the Placeholder Math extension to create dynamic goals. The extension can be found [here](https://api.extendedclip.com/expansions/math/).
+
+```yaml
+objectives:
+    - type: mobkill ## required, see type list for available types
+      dynamicGoal: "%server_online%"
+      entities: # This is an optional parameter, if it doesn't exist the quest will count ALL mob kills. entity reference: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html
+          - Zombie
+          - Pig
+          - ZOMBIFIED_PIGLIN
+      description: "Zombies & Pigs"
+```
+
 ### questDuration (required if no goal is set)
 
 The time that the quest should run for in seconds, so if it is set to 60s the quest will last for one minute. You could also do 1m to achieve the same result. If both goal and time required are set then the quest will run until the goal is hit
@@ -240,7 +257,7 @@ rewards:
 
 ```
 
-Old Rewards example (still works will be removed eventually)
+Old Rewards example (still works but will be deprecated eventually)
 
 ```yaml
 rewards:
@@ -317,6 +334,7 @@ Fishing:
 -   **experience**: players must gather Minecraft experience
 -   **carvepumpkin**: use shears on a pumpkin
 -   **mythicmob**: Kill mobs from the mythicmob plugin (requires MythicMobs to be installed)
+-   **distance**: travel a certain distance in blocks
 
 ### MythicMobs Example
 
@@ -374,3 +392,109 @@ The questId is the key used in the yml file. In the quest above the id would be 
 -   communityquests.claim - the ability to claim rewards for completed quests (skips the GUI)
 -   communityquests.claim.others - the ability to claim rewards for another player (mainly for OPs so rewards can be claimed with a custom UI)
 -   communityquests.clearrewards - the ability to clear rewards for a player (OP default)
+-   communityquests.schedule - the ability to schedule quests to start at a specific time (OP default)
+
+## Holograms
+
+This plugin now supports holograms using the [DecentHolograms](https://www.spigotmc.org/resources/decentholograms-1-8-1-21-3-papi-support-no-dependencies.96927/) plugin. Players who want to enable holograms must install DecentHolograms on their server. Holograms allow important information, such as quest details, to be displayed in-game for easy access.
+
+## Hologram Configuration
+
+Below is an example configuration for the hologram settings, which can be found in your plugin's `config.yml` file.
+
+```yml
+hologram:
+    refresh-interval: 60
+    enabled: true
+    location:
+        world: world
+        x: -78
+        y: 67
+        z: 51
+    text:
+        - "<#B22AFE>&l&nCommunity Quests</#ff8157>"
+        - "&f&lRight click to view quests"
+        - "%communityquests_name%"
+        - "%communityquests_description%"
+        - "%communityquests_top_all%"
+```
+
+### Configuration Options
+
+-   **`refresh-interval`** (Integer): The frequency (in seconds) at which the hologram refreshes. This is useful for updating dynamic information like quest names and descriptions. In this example, it’s set to refresh every 60 seconds. Set to 0 if you don't want it to refresh.
+
+-   **`enabled`** (Boolean): Toggles the hologram display on or off. Set to `true` to enable the hologram, or `false` to disable it.
+
+-   **`location`**:
+
+    -   **`world`** (String): The name of the world where the hologram will appear.
+    -   **`x`**, **`y`**, **`z`** (Integer): The coordinates for the hologram's position in the specified world.
+
+-   **`text`** (List of Strings): The lines of text that will appear in the hologram. You can use:
+    -   **Hex Colors and Formatting**: Colors can be set with hex codes in the format `<#hexcode>` (e.g., `<#B22AFE>`), along with Minecraft formatting codes like `&l` for bold or `&n` for underline.
+    -   **Placeholders**: Dynamic placeholders such as `%communityquests_name%` and `%communityquests_description%` display real-time quest information.
+
+### Example Explanation
+
+The above configuration will create a hologram that:
+
+-   Refreshes every 60 seconds.
+-   Is enabled and visible at coordinates (-78, 67, 51) in the `world`.
+-   Displays the following text:
+    -   A stylized header with the text "Community Quests" in a gradient color.
+    -   "Right click to view quests" in bold white.
+    -   Dynamic placeholders that will display the quest name, description, and top player stats.
+
+### Requirements
+
+-   **DecentHolograms Plugin**: This plugin is required for holograms to function. Please download and install it from [DecentHolograms](https://www.spigotmc.org/resources/decentholograms.96927/).
+
+### Notes
+
+Make sure to update placeholders or text based on your desired in-game display and set accurate coordinates in your world to place the hologram effectively.
+
+## Quest Scheduler
+
+Schedule quests to automatically start at specific times with configurable recurrence patterns.
+
+### Command Usage
+
+Basic command structure:
+
+```
+/cq schedulequests <questId> <coop|comp> <time> <DAILY|WEEKLY|CUSTOM_DAYS> <add|remove> [day|interval]
+```
+
+### Examples:
+
+-   Daily Quest: `/cq schedulequests mining coop 14:30 DAILY add`  
+    Starts the "mining" quest every day at 2:30 PM
+-   Weekly Quest: `/cq schedulequests fishing coop 09:00 WEEKLY add MONDAY`  
+    Starts the "fishing" quest every Monday at 9:00 AM
+-   Custom Interval: `/cq schedulequests boss comp 20:00 CUSTOM_DAYS add 3`  
+    Starts the "boss" quest every 3 days at 8:00 PM
+-   Remove Schedule: `/cq schedulequests any coop 00:00 DAILY remove <scheduleId>`  
+    Removes the schedule with the given ID
+
+### Manual Configuration (schedules.yml)
+
+You can directly configure schedules in `schedules.yml`:
+
+```yaml
+12345678-example:
+    questId: "mining" # Quest identifier
+    mode: "coop" # Mode: "coop" or "comp"
+    time: "14:30" # 24-hour format (HH:mm)
+    scheduleType: "DAILY" # DAILY, WEEKLY, or CUSTOM_DAYS
+    interval: 1 # Days between runs (for CUSTOM_DAYS only)
+    dayOfWeek: "MONDAY" # Required for WEEKLY schedule
+    enabled: true # Enable/disable the schedule
+```
+
+### Schedule Types:
+
+-   `DAILY`: Runs every day at specified time
+-   `WEEKLY`: Runs on specified day of week at specified time
+-   `CUSTOM_DAYS`: Runs every X days (specified by interval) at specified time
+
+All times must be in 24-hour format (HH:mm). Server restarts will automatically reload all enabled schedules.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.wonka01</groupId>
     <artifactId>CommunityQuests</artifactId>
-    <version>2.12.0</version>
+    <version>2.11.0</version>
 
     <contributors>
         <contributor>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.wonka01</groupId>
     <artifactId>CommunityQuests</artifactId>
-    <version>2.10.0</version>
+    <version>2.12.0</version>
 
     <contributors>
         <contributor>
@@ -66,6 +66,10 @@
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
+            <id>codemc</id>
+            <url>https://repo.codemc.io/repository/maven-public/</url>
+        </repository>
+        <repository>
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
@@ -85,6 +89,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.16.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+          <dependency>
+            <groupId>com.github.decentsoftware-eu</groupId>
+            <artifactId>decentholograms</artifactId>
+            <version>2.8.11</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/me/knighthat/apis/menus/Menu.java
+++ b/src/main/java/me/knighthat/apis/menus/Menu.java
@@ -95,7 +95,10 @@ public abstract class Menu implements InventoryHolder, Colorization {
     protected @NonNull List<String> getLoreFromData(@NonNull QuestData data) {
 
         List<String> lore = new ArrayList<>();
-        lore.add(color(data.getDescription()));
+        String[] description = data.getDescriptionArr();
+        for (String s : description) {
+            lore.add(color(s));
+        }
         lore.add(" ");
 
         int duration = data.getQuestDuration();

--- a/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
+++ b/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
@@ -2,6 +2,7 @@ package me.wonka01.ServerQuests;
 
 import lombok.Getter;
 import lombok.NonNull;
+import me.clip.placeholderapi.PlaceholderAPI;
 import me.knighthat.apis.files.Config;
 import me.knighthat.apis.files.Messages;
 import me.knighthat.apis.menus.MenuEvents;
@@ -11,6 +12,7 @@ import me.wonka01.ServerQuests.events.*;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 import me.wonka01.ServerQuests.questcomponents.bossbar.BarManager;
 import me.wonka01.ServerQuests.questcomponents.bossbar.BossbarPlayerInfo;
+import me.wonka01.ServerQuests.questcomponents.hologram.DecentHologramsDisplay;
 import me.wonka01.ServerQuests.questcomponents.rewards.RewardManager;
 import me.wonka01.placeholders.CommunityQuestsPlaceholders;
 import net.milkbowl.vault.economy.Economy;
@@ -29,6 +31,10 @@ public class ServerQuests extends JavaPlugin {
     private Economy economy;
     private MythicBukkit mythicBukkit;
     private JsonQuestSave jsonSave;
+    @Getter
+    private DecentHologramsDisplay hologram;
+    @Getter
+    private boolean isPlaceholderApiEnabled;
 
     @Override
     public void onEnable() {
@@ -45,11 +51,24 @@ public class ServerQuests extends JavaPlugin {
             getLogger().info("Warning! MythicMobs not found, MythicMobs events will not work.");
         }
 
+        if (Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) {
+            isPlaceholderApiEnabled = true;
+        } else {
+            getLogger().info("Warning! PlaceholderAPI not found, placeholders will not work.");
+            isPlaceholderApiEnabled = false;
+        }
+
         registerPlaceholders();
         registerGuiEvents();
         registerQuestEvents();
         RewardManager.getInstance().populateFromJsonFile(getDataFolder(), getLogger());
         BossbarPlayerInfo.getInstance().loadFromJsonFile(getDataFolder());
+        if (!setupDecentHologram() && getConfig().getBoolean("hologram.enabled")) {
+            getLogger().info("Warning! DecentHolograms not found, holograms will not work.");
+        } else {
+            hologram = new DecentHologramsDisplay(this);
+            hologram.displayHologram();
+        }
         getLogger().info("Plugin is enabled");
     }
 
@@ -97,6 +116,10 @@ public class ServerQuests extends JavaPlugin {
     private boolean setupMythicMobs() {
         mythicBukkit = (MythicBukkit) Bukkit.getPluginManager().getPlugin("MythicMobs");
         return mythicBukkit != null;
+    }
+
+    private boolean setupDecentHologram() {
+        return Bukkit.getPluginManager().getPlugin("DecentHolograms") != null;
     }
 
     private void registerQuestEvents() {

--- a/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
+++ b/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
@@ -58,16 +58,17 @@ public class ServerQuests extends JavaPlugin {
         }
 
         registerPlaceholders();
-        registerGuiEvents();
-        registerQuestEvents();
-        RewardManager.getInstance().populateFromJsonFile(getDataFolder(), getLogger());
-        BossbarPlayerInfo.getInstance().loadFromJsonFile(getDataFolder());
         if (!setupDecentHologram() && getConfig().getBoolean("hologram.enabled")) {
             getLogger().info("Warning! DecentHolograms not found, holograms will not work.");
         } else {
             hologram = new DecentHologramsDisplay(this);
             hologram.displayHologram();
         }
+
+        registerGuiEvents();
+        registerQuestEvents();
+        RewardManager.getInstance().populateFromJsonFile(getDataFolder(), getLogger());
+        BossbarPlayerInfo.getInstance().loadFromJsonFile(getDataFolder());
         getLogger().info("Plugin is enabled");
     }
 
@@ -136,6 +137,7 @@ public class ServerQuests extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new CraftItemQuestEvent(activeQuests), this);
         getServer().getPluginManager().registerEvents(new ConsumeItemQuestEvent(activeQuests), this);
         getServer().getPluginManager().registerEvents(new EnchantItemQuestEvent(activeQuests), this);
+        getServer().getPluginManager().registerEvents(new DistanceTraveled(activeQuests), this);
         try {
             getServer().getPluginManager().registerEvents(new ExperienceEvent(activeQuests), this);
             getServer().getPluginManager().registerEvents(new HarvestEvent(activeQuests), this);
@@ -144,6 +146,9 @@ public class ServerQuests extends JavaPlugin {
         }
         if (mythicBukkit != null) {
             getServer().getPluginManager().registerEvents(new MythicMobKillEvent(activeQuests), this);
+        }
+        if (hologram != null) {
+            getServer().getPluginManager().registerEvents(hologram, this);
         }
     }
 

--- a/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
+++ b/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
@@ -2,7 +2,6 @@ package me.wonka01.ServerQuests;
 
 import lombok.Getter;
 import lombok.NonNull;
-import me.clip.placeholderapi.PlaceholderAPI;
 import me.knighthat.apis.files.Config;
 import me.knighthat.apis.files.Messages;
 import me.knighthat.apis.menus.MenuEvents;

--- a/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
+++ b/src/main/java/me/wonka01/ServerQuests/ServerQuests.java
@@ -35,9 +35,12 @@ public class ServerQuests extends JavaPlugin {
     @Getter
     private boolean isPlaceholderApiEnabled;
 
+    @Getter
+    private CommandManager commandManager;
+
     @Override
     public void onEnable() {
-        new CommandManager(this);
+        this.commandManager = new CommandManager(this);
 
         loadSaveData();
 

--- a/src/main/java/me/wonka01/ServerQuests/commands/CommandManager.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/CommandManager.java
@@ -36,6 +36,7 @@ public class CommandManager implements CommandExecutor {
         commands.add(new EndAllCommand(plugin));
         commands.add(new ClaimRewards(plugin));
         commands.add(new ClearRewardsCommand(plugin));
+        commands.add(new QuestScheduler(plugin));
     }
 
     @Override

--- a/src/main/java/me/wonka01/ServerQuests/commands/CommandManager.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/CommandManager.java
@@ -1,5 +1,6 @@
 package me.wonka01.ServerQuests.commands;
 
+import lombok.Getter;
 import lombok.NonNull;
 import me.wonka01.ServerQuests.ServerQuests;
 import org.bukkit.command.Command;
@@ -16,6 +17,9 @@ public class CommandManager implements CommandExecutor {
     private final ServerQuests plugin;
 
     private final @NonNull List<PluginCommand> commands = new ArrayList<>(9);
+
+    @Getter
+    private QuestScheduler questScheduler;
 
     public CommandManager(ServerQuests plugin) {
 
@@ -36,7 +40,8 @@ public class CommandManager implements CommandExecutor {
         commands.add(new EndAllCommand(plugin));
         commands.add(new ClaimRewards(plugin));
         commands.add(new ClearRewardsCommand(plugin));
-        commands.add(new QuestScheduler(plugin));
+        this.questScheduler = new QuestScheduler(plugin);
+        commands.add(this.questScheduler);
     }
 
     @Override

--- a/src/main/java/me/wonka01/ServerQuests/commands/QuestScheduler.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/QuestScheduler.java
@@ -1,0 +1,284 @@
+package me.wonka01.ServerQuests.commands;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.CommandSender;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.NotNull;
+
+import lombok.NonNull;
+import me.wonka01.ServerQuests.ServerQuests;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class QuestScheduler extends PluginCommand {
+    private final ServerQuests plugin;
+    private final File scheduleFile;
+    private FileConfiguration scheduleConfig;
+    private final Map<String, BukkitRunnable> activeSchedules = new HashMap<>();
+
+    public enum ScheduleType {
+        DAILY,
+        WEEKLY,
+        CUSTOM_DAYS
+    }
+
+    public QuestScheduler(ServerQuests plugin) {
+        super(plugin, false);
+        this.plugin = plugin;
+        this.scheduleFile = new File(plugin.getDataFolder(), "schedules.yml");
+        loadSchedules();
+    }
+
+    @Override
+    public @NonNull String getName() {
+        return "schedule";
+    }
+
+    private void loadSchedules() {
+        if (!scheduleFile.exists()) {
+            plugin.saveResource("schedules.yml", false);
+        }
+        scheduleConfig = YamlConfiguration.loadConfiguration(scheduleFile);
+
+        // Load existing schedules on server start
+        for (String key : scheduleConfig.getKeys(false)) {
+            String questId = scheduleConfig.getString(key + ".questId");
+            String mode = scheduleConfig.getString(key + ".mode");
+            String time = scheduleConfig.getString(key + ".time");
+            String scheduleType = scheduleConfig.getString(key + ".scheduleType", "DAILY");
+            int interval = scheduleConfig.getInt(key + ".interval", 1);
+            String dayOfWeek = scheduleConfig.getString(key + ".dayOfWeek", "MONDAY");
+            boolean enabled = scheduleConfig.getBoolean(key + ".enabled", true);
+
+            if (enabled) {
+                scheduleQuest(key, questId, mode, time, ScheduleType.valueOf(scheduleType), interval,
+                        dayOfWeek);
+            }
+        }
+    }
+
+    private void saveSchedules() {
+        try {
+            scheduleConfig.save(scheduleFile);
+        } catch (IOException e) {
+            plugin.getLogger().severe("Could not save schedules.yml: " + e.getMessage());
+        }
+    }
+
+    public void reloadSchedules() {
+        loadSchedules();
+    }
+
+    @Override
+    public void execute(@NonNull CommandSender sender, @NotNull @NonNull String[] args) {
+        if (args.length < 5) {
+            sendUsageMessage(sender);
+            return;
+        }
+
+        String questId = args[1];
+        String mode = args[2].toLowerCase();
+        String time = args[3];
+        String scheduleTypeStr = args[4].toUpperCase();
+        String action = args[5].toLowerCase();
+
+        // check quest library to see if id exists
+        if (!plugin.config().getQuestLibrary().containsQuest(questId) || questId.equalsIgnoreCase("random")) {
+            sender.sendMessage("§cQuest with ID " + questId + " does not exist!");
+            return;
+        }
+
+        if (!mode.equals("coop") && !mode.equals("comp")) {
+            sender.sendMessage("§cMode must be either 'coop' or 'comp'!");
+            return;
+        }
+
+        ScheduleType scheduleType;
+        try {
+            scheduleType = ScheduleType.valueOf(scheduleTypeStr);
+        } catch (IllegalArgumentException e) {
+            sender.sendMessage("§cInvalid schedule type! Use DAILY, WEEKLY, or CUSTOM_DAYS");
+            return;
+        }
+
+        try {
+            DateTimeFormatter.ofPattern("HH:mm").parse(time);
+        } catch (DateTimeParseException e) {
+            sender.sendMessage("§cInvalid time format! Please use HH:mm (24-hour format)");
+            return;
+        }
+
+        // Handle scheduling
+        if (action.equals("add")) {
+            int interval = 1;
+            String dayOfWeek = "MONDAY";
+
+            // Parse additional parameters based on schedule type
+            if (scheduleType == ScheduleType.WEEKLY && args.length < 7) {
+                sender.sendMessage("§cFor weekly schedules, specify the day of week: MONDAY, TUESDAY, etc.");
+                return;
+            } else if (scheduleType == ScheduleType.CUSTOM_DAYS && args.length < 7) {
+                sender.sendMessage("§cFor custom day intervals, specify the number of days between runs");
+                return;
+            }
+
+            if (scheduleType == ScheduleType.WEEKLY) {
+                dayOfWeek = args[6].toUpperCase();
+                try {
+                    DayOfWeek.valueOf(dayOfWeek);
+                } catch (IllegalArgumentException e) {
+                    sender.sendMessage("§cInvalid day of week! Use MONDAY, TUESDAY, etc.");
+                    return;
+                }
+            } else if (scheduleType == ScheduleType.CUSTOM_DAYS) {
+                try {
+                    interval = Integer.parseInt(args[6]);
+                    if (interval < 1) {
+                        sender.sendMessage("§cInterval must be at least 1 day!");
+                        return;
+                    }
+                } catch (NumberFormatException e) {
+                    sender.sendMessage("§cInvalid interval! Please provide a number of days");
+                    return;
+                }
+            }
+
+            UUID scheduleId = UUID.randomUUID();
+
+            // Save to config
+            scheduleConfig.set(scheduleId.toString() + ".questId", questId);
+            scheduleConfig.set(scheduleId.toString() + ".mode", mode);
+            scheduleConfig.set(scheduleId.toString() + ".time", time);
+            scheduleConfig.set(scheduleId.toString() + ".scheduleType", scheduleType.name());
+            scheduleConfig.set(scheduleId.toString() + ".interval", interval);
+            scheduleConfig.set(scheduleId.toString() + ".dayOfWeek", dayOfWeek);
+            scheduleConfig.set(scheduleId.toString() + ".enabled", true);
+            saveSchedules();
+
+            // Schedule the quest
+            scheduleQuest(scheduleId.toString(), questId, mode, time, scheduleType, interval, dayOfWeek);
+            sender.sendMessage("§aQuest scheduled successfully! Schedule ID: " + scheduleId);
+
+        } else if (action.equals("remove")) {
+            if (args.length < 7) {
+                sender.sendMessage("§cPlease provide the schedule ID to remove!");
+                return;
+            }
+
+            String targetId = args[6];
+
+            if (activeSchedules.containsKey(targetId)) {
+                activeSchedules.get(targetId).cancel();
+                activeSchedules.remove(targetId);
+                scheduleConfig.set(targetId.toString(), null);
+                saveSchedules();
+                sender.sendMessage("§aSchedule removed successfully!");
+            } else {
+                sender.sendMessage("§cSchedule not found!");
+            }
+        } else {
+            sender.sendMessage("§cInvalid action! Use 'add' or 'remove'");
+        }
+    }
+
+    private void sendUsageMessage(CommandSender sender) {
+        sender.sendMessage("§cUsage:");
+        sender.sendMessage(
+                "§c/cq schedulequests <questId> <coop|comp> <time> <DAILY|WEEKLY|CUSTOM_DAYS> <add|remove> [day|interval]");
+        sender.sendMessage("§cExamples:");
+        sender.sendMessage("§c- Daily: /cq schedulequests quest1 coop 14:30 DAILY add");
+        sender.sendMessage("§c- Weekly: /cq schedulequests quest1 coop 14:30 WEEKLY add MONDAY");
+        sender.sendMessage("§c- Custom: /cq schedulequests quest1 coop 14:30 CUSTOM_DAYS add 3");
+        sender.sendMessage("§c- Remove: /cq schedulequests quest1 coop 14:30 DAILY remove <scheduleId>");
+    }
+
+    private void scheduleQuest(String scheduleId, String questId, String mode, String time, ScheduleType scheduleType,
+            int interval, String dayOfWeek) {
+        // Parse the time string to get hours and minutes
+        String[] timeParts = time.split(":");
+        int hours = Integer.parseInt(timeParts[0]);
+        int minutes = Integer.parseInt(timeParts[1]);
+
+        // Create target time for today
+        LocalDateTime targetTime = LocalDateTime.now()
+                .withHour(hours)
+                .withMinute(minutes)
+                .withSecond(0)
+                .withNano(0);
+
+        // Adjust target time based on schedule type
+        switch (scheduleType) {
+            case WEEKLY:
+                DayOfWeek targetDay = DayOfWeek.valueOf(dayOfWeek);
+                while (targetTime.getDayOfWeek() != targetDay) {
+                    targetTime = targetTime.plusDays(1);
+                }
+                break;
+            case CUSTOM_DAYS:
+                // If time today has passed, start from tomorrow
+                if (targetTime.isBefore(LocalDateTime.now())) {
+                    targetTime = targetTime.plusDays(1);
+                }
+                break;
+            case DAILY:
+                // If time today has passed, schedule for tomorrow
+                if (targetTime.isBefore(LocalDateTime.now())) {
+                    targetTime = targetTime.plusDays(1);
+                }
+                break;
+        }
+
+        // Calculate initial delay
+        long initialDelayTicks = ChronoUnit.SECONDS.between(LocalDateTime.now(), targetTime) * 20;
+        long intervalTicks;
+        switch (scheduleType) {
+            case DAILY:
+                intervalTicks = 20 * 60 * 60 * 24; // 24 hours in ticks
+                break;
+            case WEEKLY:
+                intervalTicks = 20 * 60 * 60 * 24 * 7; // 7 days in ticks
+                break;
+            case CUSTOM_DAYS:
+                intervalTicks = 20 * 60 * 60 * 24 * interval; // interval days in ticks
+                break;
+            default:
+                throw new IllegalArgumentException("Unexpected value: " + scheduleType);
+        }
+
+        BukkitRunnable task = new BukkitRunnable() {
+            @Override
+            public void run() {
+                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "cq start " + questId + " " + mode);
+                plugin.getLogger().info("Scheduled quest " + questId + " executed in " + mode + " mode");
+            }
+        };
+
+        // Schedule the task
+        task.runTaskTimer(plugin, initialDelayTicks, intervalTicks);
+        activeSchedules.put(scheduleId.toString(), task);
+    }
+
+    public void shutdown() {
+        // Cancel all active schedules when the plugin is disabled
+        for (BukkitRunnable task : activeSchedules.values()) {
+            task.cancel();
+        }
+        activeSchedules.clear();
+    }
+
+    @Override
+    public @NonNull String getPermission() {
+        return "communityquests.schedule";
+    }
+}

--- a/src/main/java/me/wonka01/ServerQuests/commands/QuestScheduler.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/QuestScheduler.java
@@ -23,7 +23,7 @@ import java.util.UUID;
 
 public class QuestScheduler extends PluginCommand {
     private final ServerQuests plugin;
-    private final File scheduleFile;
+    private File scheduleFile;
     private FileConfiguration scheduleConfig;
     private final Map<String, BukkitRunnable> activeSchedules = new HashMap<>();
 
@@ -77,6 +77,7 @@ public class QuestScheduler extends PluginCommand {
     }
 
     public void reloadSchedules() {
+        // this.scheduleFile = new File(plugin.getDataFolder(), "schedules.yml");
         loadSchedules();
     }
 

--- a/src/main/java/me/wonka01/ServerQuests/commands/ReloadCommand.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/ReloadCommand.java
@@ -37,6 +37,7 @@ public class ReloadCommand extends PluginCommand {
         }
 
         getPlugin().messages().reload();
+        getPlugin().getCommandManager().getQuestScheduler().reloadSchedules();
 
         String reloadMessage = getPlugin().messages().message("reloadCommand");
         sender.sendMessage(reloadMessage);

--- a/src/main/java/me/wonka01/ServerQuests/commands/ReloadCommand.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/ReloadCommand.java
@@ -27,6 +27,14 @@ public class ReloadCommand extends PluginCommand {
         getPlugin().config().reload();
         getPlugin().config().initializeVariables();
         getPlugin().config().initializeQuests();
+        if (getPlugin().getHologram() != null) {
+            if (getPlugin().getConfig().getBoolean("hologram.enabled")) {
+                getPlugin().getHologram().reloadConfig();
+                getPlugin().getHologram().displayHologram();
+            } else {
+                getPlugin().getHologram().removeHologram();
+            }
+        }
 
         getPlugin().messages().reload();
 

--- a/src/main/java/me/wonka01/ServerQuests/commands/StartCommand.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/StartCommand.java
@@ -6,6 +6,8 @@ import me.wonka01.ServerQuests.configuration.QuestModel;
 import me.wonka01.ServerQuests.enums.EventType;
 import me.wonka01.ServerQuests.gui.StartMenu;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
+
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -28,6 +30,8 @@ public class StartCommand extends PluginCommand {
 
     @Override
     public void execute(@NonNull CommandSender sender, @NotNull @NonNull String[] args) {
+        Bukkit.broadcastMessage("Starting a new quest");
+        Bukkit.broadcastMessage("Sender: " + sender.getName());
         if (args.length >= 3) {
             QuestModel model = getPlugin().config().getQuestLibrary().getQuestModelById(args[1]);
             if (model == null) {

--- a/src/main/java/me/wonka01/ServerQuests/commands/StartCommand.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/StartCommand.java
@@ -7,7 +7,6 @@ import me.wonka01.ServerQuests.enums.EventType;
 import me.wonka01.ServerQuests.gui.StartMenu;
 import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
 
-import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -30,8 +29,6 @@ public class StartCommand extends PluginCommand {
 
     @Override
     public void execute(@NonNull CommandSender sender, @NotNull @NonNull String[] args) {
-        Bukkit.broadcastMessage("Starting a new quest");
-        Bukkit.broadcastMessage("Sender: " + sender.getName());
         if (args.length >= 3) {
             QuestModel model = getPlugin().config().getQuestLibrary().getQuestModelById(args[1]);
             if (model == null) {

--- a/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestHistory.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestHistory.java
@@ -1,0 +1,31 @@
+package me.wonka01.ServerQuests.configuration;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.bukkit.Bukkit;
+
+import me.wonka01.ServerQuests.ServerQuests;
+
+public class JsonQuestHistory {
+    private final ServerQuests plugin;
+    private final File path;
+
+    public JsonQuestHistory(ServerQuests plugin, File path) {
+        this.plugin = plugin;
+        this.path = new File(path + "/questSave.json");
+    }
+
+    public boolean getOrCreateQuestFile() {
+        if (path.exists()) {
+            return true;
+        } else {
+            try {
+                path.createNewFile();
+            } catch (IOException e) {
+                Bukkit.getServer().getConsoleSender().sendMessage(e.getMessage());
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
@@ -117,6 +117,7 @@ public class JsonQuestSave {
                     JSONObject obj = oIterator.next();
                     String type = (String) obj.get("type");
                     double goal = (double) obj.get("goal");
+                    String dynamicGoal = (String) obj.getOrDefault("dynamicGoal", "");
                     double amount = (double) obj.get("amountComplete");
                     JSONArray mobNames = (JSONArray) obj.get("mobNames");
                     JSONArray materials = (JSONArray) obj.get("materials");
@@ -132,7 +133,8 @@ public class JsonQuestSave {
 
                     ObjectiveType objectiveType = ObjectiveType.match(type);
                     Objective objective = new Objective(objectiveType, goal, amount, convertJsonArrayToList(mobNames),
-                            materialList, (String) obj.get("description"), convertJsonArrayToList(customNames));
+                            materialList, (String) obj.get("description"), convertJsonArrayToList(customNames),
+                            dynamicGoal);
                     objectives.add(objective);
                 }
                 long questDuration = (Long) questObject.getOrDefault("timeLeft", 0);

--- a/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
@@ -63,7 +63,7 @@ public class JsonQuestSave {
             jObject.put("playerMap", questController.getPlayerComponent().toJSONArray());
             JSONArray objectives = new JSONArray();
             for (int i = 0; i < questController.getQuestData().getObjectives().size(); i++) {
-                objectives.add(questController.getQuestData().getObjectives().get(i).getObjectiveJSON());
+                objectives.add(questController.getQuestData().getObjectives().get(i).toJsonObject());
             }
             jObject.put("objectives", objectives);
             jObject.put("timeLeft", questController.getQuestData().getQuestDuration());

--- a/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
@@ -152,9 +152,9 @@ public class JsonQuestSave {
                         randomNames.add("NotSoJuicyJuan");
                         randomNames.add("Notch");
                         randomNames.add("Availer");
+                        randomNames.add("Vaquxine");
                         randomNames.add("Taco");
-                        randomNames.add("Cheeseburger");
-                        randomNames.add("Sword4000");
+                        randomNames.add("ish");
                         playerName = randomNames.get((int) (Math.random() * randomNames.size()));
                     }
                     Gson gson = new Gson();

--- a/src/main/java/me/wonka01/ServerQuests/configuration/QuestLibrary.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/QuestLibrary.java
@@ -7,6 +7,7 @@ import me.wonka01.ServerQuests.questcomponents.rewards.*;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
+import org.bukkit.boss.BarStyle;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -22,6 +23,10 @@ public class QuestLibrary {
 
     public QuestModel getQuestModelById(String questId) {
         return questList.get(questId);
+    }
+
+    public boolean containsQuest(String questId) {
+        return questList.containsKey(questId);
     }
 
     public void loadQuestConfiguration(ConfigurationSection serverQuestConfig) {
@@ -57,6 +62,8 @@ public class QuestLibrary {
         String beforeQuestCommand = section.getString("beforeQuestCommand", "");
         String questFailedCommand = section.getString("questFailedCommand", "");
         String barColor = section.getString("barColor", "");
+        String barStyle = section.getString("barStyle", "SOLID");
+        BarStyle style = BarStyle.valueOf(barStyle.toUpperCase());
 
         List<Objective> objectives = null;
         List<String> mobNames = null;
@@ -87,6 +94,7 @@ public class QuestLibrary {
                 } else if (obj.get("goal") instanceof Double) {
                     objectiveGoal = (Double) obj.get("goal");
                 }
+                String dynamicGoal = (String) obj.get("dynamicGoal");
                 String objDescription = (String) obj.get("description");
                 List<String> objectiveMobs = (List<String>) obj.get("entities");
                 List<String> objectiveMaterials = (List<String>) obj.get("materials");
@@ -114,7 +122,7 @@ public class QuestLibrary {
                 }
 
                 Objective objective = new Objective(objectiveTypeEnum, objectiveGoal, 0.0, objectiveMobs,
-                        mats, objDescription, objectiveCustomNames);
+                        mats, objDescription, objectiveCustomNames, dynamicGoal);
                 objectives.add(objective);
             }
         }
@@ -145,7 +153,7 @@ public class QuestLibrary {
         return new QuestModel(questId, displayName, description, goal,
                 type, mobNames, rewards, materials, displayItem, worlds, questDuration, rewardsLimit, afterQuestCommand,
                 beforeQuestCommand, objectives, questFailedCommand, customMobNames, barColor, rankedRewardsMap,
-                rankedRewardMessages);
+                rankedRewardMessages, style);
     }
 
     private ArrayList<Reward> getRewardsFromConfig(ConfigurationSection section) {

--- a/src/main/java/me/wonka01/ServerQuests/configuration/QuestLibrary.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/QuestLibrary.java
@@ -152,7 +152,8 @@ public class QuestLibrary {
 
         return new QuestModel(questId, displayName, description, goal,
                 type, mobNames, rewards, materials, displayItem, worlds, questDuration, rewardsLimit, afterQuestCommand,
-                beforeQuestCommand, objectives, questFailedCommand, customMobNames, barColor, rankedRewardsMap,
+                beforeQuestCommand, objectives, questFailedCommand, customMobNames, barColor.toUpperCase(),
+                rankedRewardsMap,
                 rankedRewardMessages, style);
     }
 

--- a/src/main/java/me/wonka01/ServerQuests/configuration/QuestModel.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/QuestModel.java
@@ -8,6 +8,7 @@ import me.wonka01.ServerQuests.questcomponents.rewards.Reward;
 import me.wonka01.ServerQuests.questcomponents.schedulers.ParseDurationString;
 
 import org.bukkit.Material;
+import org.bukkit.boss.BarStyle;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +36,7 @@ public class QuestModel {
     private final String barColor;
     private final Map<String, ArrayList<Reward>> rankedRewards;
     private final Map<String, String> rankedRewardMessages;
+    private final BarStyle barStyle;
 
     public QuestModel(String questId, String displayName, String eventDescription,
             int questGoal, ObjectiveType objective,
@@ -42,7 +44,7 @@ public class QuestModel {
             List<String> worlds, String questDuration, int rewardLimit, String afterQuestCommand,
             String beforeQuestCommand, List<Objective> objectives, String questFailedCommand,
             List<String> customNames, String barColor, Map<String, ArrayList<Reward>> rankedRewards,
-            Map<String, String> rankedRewardMessages) {
+            Map<String, String> rankedRewardMessages, BarStyle barStyle) {
         this.questId = questId;
         this.displayName = displayName;
         this.eventDescription = eventDescription;
@@ -50,6 +52,7 @@ public class QuestModel {
         this.questGoal = questGoal;
         this.questFailedCommand = questFailedCommand;
         this.barColor = barColor;
+        this.barStyle = barStyle;
 
         List<Material> materials = new ArrayList<>();
         if (itemNames != null) {
@@ -68,7 +71,7 @@ public class QuestModel {
         } else {
             this.objectives = Arrays
                     .asList(new Objective(objective, questGoal * 1.0, 0, mobNames, materials, objective.getString(),
-                            customNames));
+                            customNames, ""));
         }
         this.mobNames = mobNames;
         this.rewards = rewards;

--- a/src/main/java/me/wonka01/ServerQuests/configuration/QuestModel.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/QuestModel.java
@@ -96,4 +96,11 @@ public class QuestModel {
             }
         }
     }
+
+    public String[] getEventDescriptionArray() {
+        if (eventDescription == null) {
+            return new String[0];
+        }
+        return eventDescription.split("\n");
+    }
 }

--- a/src/main/java/me/wonka01/ServerQuests/configuration/QuestModel.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/QuestModel.java
@@ -101,6 +101,6 @@ public class QuestModel {
         if (eventDescription == null) {
             return new String[0];
         }
-        return eventDescription.split("\n");
+        return eventDescription.split("\\\\n|\\r?\\n");
     }
 }

--- a/src/main/java/me/wonka01/ServerQuests/enums/ObjectiveType.java
+++ b/src/main/java/me/wonka01/ServerQuests/enums/ObjectiveType.java
@@ -39,7 +39,6 @@ public enum ObjectiveType {
     }
 
     public static @NonNull ObjectiveType match(@Nullable String objective) {
-
         if (objective != null)
             for (ObjectiveType type : values())
                 if (type.name().equalsIgnoreCase(objective) ||

--- a/src/main/java/me/wonka01/ServerQuests/enums/ObjectiveType.java
+++ b/src/main/java/me/wonka01/ServerQuests/enums/ObjectiveType.java
@@ -24,6 +24,7 @@ public enum ObjectiveType {
     HARVEST("harvest", Material.WHEAT),
     MYTHIC_MOB("mythicmob", Material.DRAGON_EGG),
     CARVE_PUMPKIN("carvepumpkin", Material.CARVED_PUMPKIN),
+    MOVEMENT("movement", Material.DIAMOND_BOOTS),
     UNKNOWN("unknown", Material.AIR);
 
     @Getter

--- a/src/main/java/me/wonka01/ServerQuests/events/DistanceTraveled.java
+++ b/src/main/java/me/wonka01/ServerQuests/events/DistanceTraveled.java
@@ -1,0 +1,38 @@
+package me.wonka01.ServerQuests.events;
+
+import me.wonka01.ServerQuests.enums.ObjectiveType;
+import me.wonka01.ServerQuests.questcomponents.ActiveQuests;
+import me.wonka01.ServerQuests.questcomponents.QuestController;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+import java.util.List;
+
+public class DistanceTraveled extends QuestListener implements Listener {
+
+    public DistanceTraveled(ActiveQuests activeQuests) {
+        super(activeQuests);
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerMove(PlayerMoveEvent event) {
+        Location from = event.getFrom();
+        Location to = event.getTo();
+
+        if (to == null || (from.getBlockX() == to.getBlockX()
+                && from.getBlockY() == to.getBlockY()
+                && from.getBlockZ() == to.getBlockZ())) {
+            return;
+        }
+
+        double distance = from.distance(to);
+
+        List<QuestController> controllers = tryGetControllersOfObjectiveType(ObjectiveType.MOVEMENT);
+        for (QuestController controller : controllers) {
+            updateQuest(controller, event.getPlayer(), distance, ObjectiveType.MOVEMENT);
+        }
+    }
+}

--- a/src/main/java/me/wonka01/ServerQuests/gui/DonateMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/DonateMenu.java
@@ -101,7 +101,7 @@ public class DonateMenu extends Menu {
                 if (requirements.isEmpty() || requirements.contains(inputItem.getType())) {
                     boolean updateResult = updateQuest(ctrl, inputItem, objective, counter);
                     if (updateResult) {
-                        if (total > goal) {
+                        if (total > goal && goal > 0) {
                             int diff = (int) total - (int) goal;
                             inputItem.setAmount(diff);
                         } else {

--- a/src/main/java/me/wonka01/ServerQuests/gui/StartMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/StartMenu.java
@@ -9,6 +9,7 @@ import me.wonka01.ServerQuests.configuration.QuestModel;
 import me.wonka01.ServerQuests.objectives.Objective;
 import me.wonka01.ServerQuests.questcomponents.schedulers.ParseDurationString;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
@@ -29,7 +30,9 @@ public class StartMenu extends Menu {
             List<String> lore = new ArrayList<>();
 
             String[] eventDescriptionArr = model.getEventDescriptionArray();
+            Bukkit.broadcastMessage("eventDescriptionArr: " + eventDescriptionArr.length);
             for (String s : eventDescriptionArr) {
+                Bukkit.broadcastMessage("line: " + s);
                 lore.add(s);
             }
 

--- a/src/main/java/me/wonka01/ServerQuests/gui/StartMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/StartMenu.java
@@ -28,18 +28,9 @@ public class StartMenu extends Menu {
             QuestModel model = getQuestModel(key);
             List<String> lore = new ArrayList<>();
 
-            try {
-                if (model.getEventDescription().contains("\n")) {
-                    String[] split = model.getEventDescription().split("\n");
-                    for (String s : split) {
-                        lore.add(s);
-                    }
-                } else {
-                    lore.add(model.getEventDescription());
-                }
-            } catch (Exception exception) {
-                exception.printStackTrace();
-                lore.add(model.getEventDescription());
+            String[] eventDescriptionArr = model.getEventDescriptionArray();
+            for (String s : eventDescriptionArr) {
+                lore.add(s);
             }
 
             int completeTime = model.getCompleteTime();

--- a/src/main/java/me/wonka01/ServerQuests/gui/StartMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/StartMenu.java
@@ -2,11 +2,9 @@ package me.wonka01.ServerQuests.gui;
 
 import lombok.NonNull;
 import me.knighthat.apis.menus.Menu;
-import me.knighthat.apis.utils.Utils;
 import me.wonka01.ServerQuests.ServerQuests;
 import me.wonka01.ServerQuests.configuration.QuestLibrary;
 import me.wonka01.ServerQuests.configuration.QuestModel;
-import me.wonka01.ServerQuests.objectives.Objective;
 import me.wonka01.ServerQuests.questcomponents.schedulers.ParseDurationString;
 
 import org.bukkit.Bukkit;
@@ -30,9 +28,7 @@ public class StartMenu extends Menu {
             List<String> lore = new ArrayList<>();
 
             String[] eventDescriptionArr = model.getEventDescriptionArray();
-            Bukkit.broadcastMessage("eventDescriptionArr: " + eventDescriptionArr.length);
             for (String s : eventDescriptionArr) {
-                Bukkit.broadcastMessage("line: " + s);
                 lore.add(s);
             }
 

--- a/src/main/java/me/wonka01/ServerQuests/gui/StartMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/StartMenu.java
@@ -26,9 +26,21 @@ public class StartMenu extends Menu {
     protected void setContents() {
         for (String key : getLibrary().getAllQuestKeys()) {
             QuestModel model = getQuestModel(key);
-
             List<String> lore = new ArrayList<>();
-            lore.add(model.getEventDescription());
+
+            try {
+                if (model.getEventDescription().contains("\n")) {
+                    String[] split = model.getEventDescription().split("\n");
+                    for (String s : split) {
+                        lore.add(s);
+                    }
+                } else {
+                    lore.add(model.getEventDescription());
+                }
+            } catch (Exception exception) {
+                exception.printStackTrace();
+                lore.add(model.getEventDescription());
+            }
 
             int completeTime = model.getCompleteTime();
 

--- a/src/main/java/me/wonka01/ServerQuests/gui/StopMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/StopMenu.java
@@ -29,7 +29,10 @@ public class StopMenu extends Menu {
             QuestData data = controller.getQuestData();
 
             List<String> lore = new ArrayList<>();
-            lore.add(data.getDescription());
+            String[] eventDescriptionArr = data.getDescriptionArr();
+            for (String s : eventDescriptionArr) {
+                lore.add(s);
+            }
             lore.add(" ");
             lore.add(progressStr + ": &a" + completed + "/" + Utils.decimalToString(data.getQuestGoal()));
             lore.add(getPlugin().messages().string("endQuestText"));

--- a/src/main/java/me/wonka01/ServerQuests/gui/StopMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/StopMenu.java
@@ -24,16 +24,14 @@ public class StopMenu extends Menu {
     @Override
     protected void setContents() {
         for (QuestController controller : getControllers()) {
-
-
             String completed = Utils.decimalToString(controller.getQuestData().getAmountCompleted()),
-                progressStr = getPlugin().messages().string("progress");
+                    progressStr = getPlugin().messages().string("progress");
             QuestData data = controller.getQuestData();
 
             List<String> lore = new ArrayList<>();
             lore.add(data.getDescription());
             lore.add(" ");
-            lore.add(progressStr + ": &a" + completed + "/" + data.getQuestGoal());
+            lore.add(progressStr + ": &a" + completed + "/" + Utils.decimalToString(data.getQuestGoal()));
             lore.add(getPlugin().messages().string("endQuestText"));
 
             ItemStack item = super.createItemStack(data.getDisplayItem(), data.getDisplayName(), lore);

--- a/src/main/java/me/wonka01/ServerQuests/gui/ViewMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/ViewMenu.java
@@ -8,6 +8,7 @@ import me.wonka01.ServerQuests.objectives.Objective;
 import me.wonka01.ServerQuests.questcomponents.CompetitiveQuestData;
 import me.wonka01.ServerQuests.questcomponents.QuestController;
 import me.wonka01.ServerQuests.questcomponents.QuestData;
+import me.wonka01.ServerQuests.questcomponents.players.BasePlayerComponent;
 import me.wonka01.ServerQuests.questcomponents.players.PlayerData;
 
 import org.bukkit.entity.Player;
@@ -68,15 +69,16 @@ public class ViewMenu extends Menu {
 
     private void getTopPlayerString(QuestController controller, List<String> lore) {
         String noData = "&7n/a";
-        ArrayList<PlayerData> top3Players = controller.getPlayerComponent().getTopPlayers(3);
+        int size = BasePlayerComponent.getLeaderBoardSize();
+        ArrayList<PlayerData> topPlayers = controller.getPlayerComponent().getTopPlayers(size);
 
-        if (top3Players.size() < 1) {
+        if (topPlayers.size() < 1) {
             lore.add(color(noData));
             return;
         }
 
-        for (int i = 0; i < top3Players.size(); i++) {
-            PlayerData topPlayer = top3Players.get(i);
+        for (int i = 0; i < topPlayers.size(); i++) {
+            PlayerData topPlayer = topPlayers.get(i);
             if (topPlayer == null) {
                 break;
             }

--- a/src/main/java/me/wonka01/ServerQuests/objectives/Objective.java
+++ b/src/main/java/me/wonka01/ServerQuests/objectives/Objective.java
@@ -49,7 +49,7 @@ public class Objective implements Cloneable {
         amountComplete += amount;
     }
 
-    public JSONObject getObjectiveJSON() {
+    public JSONObject toJsonObject() {
         JSONObject objectiveJson = new JSONObject();
         objectiveJson.put("type", type.getString());
         objectiveJson.put("goal", goal);

--- a/src/main/java/me/wonka01/ServerQuests/objectives/Objective.java
+++ b/src/main/java/me/wonka01/ServerQuests/objectives/Objective.java
@@ -15,16 +15,18 @@ import me.wonka01.ServerQuests.enums.ObjectiveType;
 @Getter
 public class Objective implements Cloneable {
     private final ObjectiveType type;
-    private final double goal;
+    @Setter
+    private double goal;
     @Setter
     private double amountComplete;
     private List<String> mobNames;
     private List<Material> materials;
     private List<String> customNames;
     private String description;
+    private String dynamicGoal;
 
     public Objective(ObjectiveType type, double goal, double amountComplete, List<String> mobNames,
-            List<Material> materials, String description, List<String> customNames) {
+            List<Material> materials, String description, List<String> customNames, String dynamicGoal) {
         this.type = type;
         this.goal = goal;
         this.amountComplete = amountComplete;
@@ -32,6 +34,7 @@ public class Objective implements Cloneable {
         this.materials = materials;
         this.description = description;
         this.customNames = customNames;
+        this.dynamicGoal = dynamicGoal;
     }
 
     public boolean isGoalComplete() {
@@ -60,6 +63,6 @@ public class Objective implements Cloneable {
     }
 
     public Objective clone() {
-        return new Objective(type, goal, amountComplete, mobNames, materials, description, customNames);
+        return new Objective(type, goal, amountComplete, mobNames, materials, description, customNames, dynamicGoal);
     }
 }

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/ActiveQuests.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/ActiveQuests.java
@@ -1,7 +1,10 @@
 package me.wonka01.ServerQuests.questcomponents;
 
+import me.clip.placeholderapi.PlaceholderAPI;
+import me.wonka01.ServerQuests.ServerQuests;
 import me.wonka01.ServerQuests.configuration.QuestModel;
 import me.wonka01.ServerQuests.enums.EventType;
+import me.wonka01.ServerQuests.objectives.Objective;
 import me.wonka01.ServerQuests.questcomponents.bossbar.BarManager;
 
 import java.util.ArrayList;
@@ -9,6 +12,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Server;
+import org.bukkit.plugin.java.JavaPlugin;
 
 // Singleton class that stores all active quests running on the server
 public class ActiveQuests {
@@ -61,6 +66,25 @@ public class ActiveQuests {
         activeQuestsList.add(controller);
         if (questModel.getBeforeQuestCommand() != null && !questModel.getBeforeQuestCommand().isEmpty()) {
             Bukkit.dispatchCommand(Bukkit.getConsoleSender(), questModel.getBeforeQuestCommand());
+        }
+
+        ServerQuests plugin = JavaPlugin.getPlugin(ServerQuests.class);
+        if (plugin.isPlaceholderApiEnabled()) {
+            try {
+                for (Objective obj : controller.getQuestData().getObjectives()) {
+                    if (!obj.getDynamicGoal().isEmpty()) {
+                        String dynamicGoal = obj.getDynamicGoal();
+                        Bukkit.getLogger().info("Dynamic goal: " + dynamicGoal);
+                        String placeholderValue = PlaceholderAPI.setPlaceholders(null, dynamicGoal);
+                        Bukkit.getLogger().info("Dynamic value: " + placeholderValue);
+
+                        obj.setGoal(Integer.parseInt(placeholderValue));
+                    }
+                }
+            } catch (Exception e) {
+                plugin.getLogger().info("Error setting dynamic goal for quest: " + questModel.getDisplayName());
+                plugin.getLogger().info("Error: " + e.getMessage());
+            }
         }
 
         controller.broadcast("questStartMessage");

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/ActiveQuests.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/ActiveQuests.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
-import org.bukkit.Server;
 import org.bukkit.plugin.java.JavaPlugin;
 
 // Singleton class that stores all active quests running on the server
@@ -72,12 +71,9 @@ public class ActiveQuests {
         if (plugin.isPlaceholderApiEnabled()) {
             try {
                 for (Objective obj : controller.getQuestData().getObjectives()) {
-                    if (!obj.getDynamicGoal().isEmpty()) {
+                    if (obj.getDynamicGoal() != null && !obj.getDynamicGoal().isEmpty()) {
                         String dynamicGoal = obj.getDynamicGoal();
-                        Bukkit.getLogger().info("Dynamic goal: " + dynamicGoal);
                         String placeholderValue = PlaceholderAPI.setPlaceholders(null, dynamicGoal);
-                        Bukkit.getLogger().info("Dynamic value: " + placeholderValue);
-
                         obj.setGoal(Integer.parseInt(placeholderValue));
                     }
                 }

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestData.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestData.java
@@ -68,7 +68,7 @@ public class QuestData implements Colorization {
         if (getDescription() == null)
             return new String[0];
 
-        return getDescription().split("\n");
+        return getDescription().split("\\\\n|\\r?\\n");
     }
 
     public String getDisplayName() {

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestData.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestData.java
@@ -64,6 +64,13 @@ public class QuestData implements Colorization {
         return placeholderDescription;
     }
 
+    public String[] getDescriptionArr() {
+        if (getDescription() == null)
+            return new String[0];
+
+        return getDescription().split("\n");
+    }
+
     public String getDisplayName() {
         String placeholderDisplayName = displayName;
         if (ServerQuests.getPlugin(ServerQuests.class).isPlaceholderApiEnabled()) {

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestData.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestData.java
@@ -2,7 +2,9 @@ package me.wonka01.ServerQuests.questcomponents;
 
 import lombok.Getter;
 import lombok.NonNull;
+import me.clip.placeholderapi.PlaceholderAPI;
 import me.knighthat.apis.utils.Colorization;
+import me.wonka01.ServerQuests.ServerQuests;
 import me.wonka01.ServerQuests.enums.EventType;
 import me.wonka01.ServerQuests.enums.ObjectiveType;
 import me.wonka01.ServerQuests.objectives.Objective;
@@ -12,6 +14,8 @@ import java.util.stream.Collectors;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
+
+import eu.decentsoftware.holograms.api.utils.scheduler.S;
 
 @Getter
 public class QuestData implements Colorization {
@@ -49,6 +53,24 @@ public class QuestData implements Colorization {
 
     public double getQuestGoal() {
         return objectives.stream().mapToDouble(Objective::getGoal).sum();
+    }
+
+    public String getDescription() {
+        String placeholderDescription = description;
+        if (ServerQuests.getPlugin(ServerQuests.class).isPlaceholderApiEnabled()) {
+            placeholderDescription = PlaceholderAPI.setPlaceholders(null, description);
+        }
+
+        return placeholderDescription;
+    }
+
+    public String getDisplayName() {
+        String placeholderDisplayName = displayName;
+        if (ServerQuests.getPlugin(ServerQuests.class).isPlaceholderApiEnabled()) {
+            placeholderDisplayName = PlaceholderAPI.setPlaceholders(null, displayName);
+        }
+
+        return placeholderDisplayName;
     }
 
     public double getAmountCompletedByType(ObjectiveType type) {

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestTypeHandler.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/QuestTypeHandler.java
@@ -46,7 +46,7 @@ public class QuestTypeHandler {
             barColor = plugin.getConfig().getString("barColor", "GREEN");
         }
 
-        QuestBar bar = new QuestBar(model.getDisplayName(), barColor);
+        QuestBar bar = new QuestBar(model.getDisplayName(), barColor, model.getBarStyle());
 
         BasePlayerComponent pComponent = new BasePlayerComponent(model.getRewards(), model.getRewardLimit(),
                 model.getRankedRewards());

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
@@ -19,7 +19,7 @@ public class QuestBar implements Colorization {
         bar = Bukkit.createBossBar(color(name), this.barColor, style);
         bar.setVisible(true);
         bar.setProgress(0.0);
-        bar.setColor(this.barColor);
+        bar.setColor(BarColor.BLUE);
     }
 
     private @NonNull BarColor getBarColor(@NonNull String color) {

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
@@ -14,12 +14,12 @@ public class QuestBar implements Colorization {
     private final BossBar bar;
 
     public QuestBar(@NonNull String name, @NonNull String color, @NonNull BarStyle style) {
-        Bukkit.broadcastMessage("Adding with color " + color);
         this.barColor = getBarColor(color);
         Bukkit.broadcastMessage("Actually adding with color " + this.barColor.toString());
         bar = Bukkit.createBossBar(color(name), this.barColor, style);
         bar.setVisible(true);
         bar.setProgress(0.0);
+        bar.setColor(this.barColor);
     }
 
     private @NonNull BarColor getBarColor(@NonNull String color) {

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
@@ -1,6 +1,7 @@
 package me.wonka01.ServerQuests.questcomponents.bossbar;
 
 import lombok.NonNull;
+import lombok.Setter;
 import me.knighthat.apis.utils.Colorization;
 import org.bukkit.Bukkit;
 import org.bukkit.boss.BarColor;
@@ -9,13 +10,14 @@ import org.bukkit.boss.BossBar;
 import org.bukkit.entity.Player;
 
 public class QuestBar implements Colorization {
-
-    private final @NonNull BarColor color;
+    private final @NonNull BarColor barColor;
     private final BossBar bar;
 
-    public QuestBar(@NonNull String name, @NonNull String color) {
-        this.color = getBarColor(color);
-        bar = Bukkit.createBossBar(color(name), this.color, BarStyle.SEGMENTED_12);
+    public QuestBar(@NonNull String name, @NonNull String color, @NonNull BarStyle style) {
+        Bukkit.broadcastMessage("Adding with color " + color);
+        this.barColor = getBarColor(color);
+        Bukkit.broadcastMessage("Actually adding with color " + this.barColor.toString());
+        bar = Bukkit.createBossBar(color(name), this.barColor, style);
         bar.setVisible(true);
         bar.setProgress(0.0);
     }

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
@@ -19,7 +19,6 @@ public class QuestBar implements Colorization {
         bar = Bukkit.createBossBar(color(name), this.barColor, style);
         bar.setVisible(true);
         bar.setProgress(0.0);
-        bar.setColor(BarColor.BLUE);
     }
 
     private @NonNull BarColor getBarColor(@NonNull String color) {

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/hologram/DecentHologramsDisplay.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/hologram/DecentHologramsDisplay.java
@@ -37,8 +37,10 @@ public class DecentHologramsDisplay implements Listener {
     }
 
     private void startRefreshTimer() {
-        long refreshInterval = config.getLong("hologram.refresh-interval", 60L);
-
+        long refreshInterval = config.getLong("hologram.refresh-interval", 0L);
+        if (refreshInterval == 0) {
+            return;
+        }
         long refreshTicks = refreshInterval * 20L;
 
         refreshTask = new BukkitRunnable() {

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/hologram/DecentHologramsDisplay.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/hologram/DecentHologramsDisplay.java
@@ -1,0 +1,54 @@
+package me.wonka01.ServerQuests.questcomponents.hologram;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.configuration.file.FileConfiguration;
+import org.checkerframework.checker.units.qual.C;
+
+import eu.decentsoftware.holograms.api.DHAPI;
+import eu.decentsoftware.holograms.api.actions.ClickType;
+import eu.decentsoftware.holograms.api.holograms.Hologram;
+import eu.decentsoftware.holograms.event.HologramClickEvent;
+import me.wonka01.ServerQuests.ServerQuests;
+import me.wonka01.ServerQuests.gui.ViewMenu;
+
+public class DecentHologramsDisplay {
+    private FileConfiguration config;
+    private Hologram holo;
+    private ServerQuests plugin;
+
+    public DecentHologramsDisplay(ServerQuests plugin) {
+        this.config = plugin.config().get();
+        this.plugin = plugin;
+        this.holo = null;
+    }
+
+    public void reloadConfig() {
+        this.config = plugin.config().get();
+    }
+
+    public void displayHologram() {
+        if (holo != null) {
+            holo.delete();
+        }
+        Location loc = new Location(Bukkit.getWorld(config.getString("hologram.location.world")),
+                config.getDouble("hologram.location.x"), config.getDouble("hologram.location.y"),
+                config.getDouble("hologram.location.z"));
+        holo = DHAPI.createHologram("ServerQuestsHologram", loc);
+        for (String line : config.getStringList("hologram.text")) {
+            DHAPI.addHologramLine(holo, line);
+        }
+    }
+
+    public void removeHologram() {
+        if (holo != null) {
+            holo.delete();
+        }
+    }
+
+    public void onPlayerClick(HologramClickEvent event) {
+        if (event.getClick().equals(ClickType.RIGHT)) {
+            new ViewMenu(plugin, event.getPlayer()).open();
+        }
+    }
+}

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/hologram/DecentHologramsDisplay.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/hologram/DecentHologramsDisplay.java
@@ -3,28 +3,57 @@ package me.wonka01.ServerQuests.questcomponents.hologram;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.file.FileConfiguration;
-import org.checkerframework.checker.units.qual.C;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
 
 import eu.decentsoftware.holograms.api.DHAPI;
 import eu.decentsoftware.holograms.api.actions.ClickType;
 import eu.decentsoftware.holograms.api.holograms.Hologram;
 import eu.decentsoftware.holograms.event.HologramClickEvent;
+import me.clip.placeholderapi.PlaceholderAPI;
 import me.wonka01.ServerQuests.ServerQuests;
 import me.wonka01.ServerQuests.gui.ViewMenu;
 
-public class DecentHologramsDisplay {
+public class DecentHologramsDisplay implements Listener {
     private FileConfiguration config;
     private Hologram holo;
     private ServerQuests plugin;
+    private BukkitTask refreshTask;
 
     public DecentHologramsDisplay(ServerQuests plugin) {
         this.config = plugin.config().get();
         this.plugin = plugin;
         this.holo = null;
+        startRefreshTimer();
     }
 
     public void reloadConfig() {
         this.config = plugin.config().get();
+        // Restart timer with new config values
+        stopRefreshTimer();
+        startRefreshTimer();
+    }
+
+    private void startRefreshTimer() {
+        long refreshInterval = config.getLong("hologram.refresh-interval", 60L);
+
+        long refreshTicks = refreshInterval * 20L;
+
+        refreshTask = new BukkitRunnable() {
+            @Override
+            public void run() {
+                displayHologram();
+            }
+        }.runTaskTimer(plugin, refreshTicks, refreshTicks);
+    }
+
+    private void stopRefreshTimer() {
+        if (refreshTask != null && !refreshTask.isCancelled()) {
+            refreshTask.cancel();
+            refreshTask = null;
+        }
     }
 
     public void displayHologram() {
@@ -36,19 +65,33 @@ public class DecentHologramsDisplay {
                 config.getDouble("hologram.location.z"));
         holo = DHAPI.createHologram("ServerQuestsHologram", loc);
         for (String line : config.getStringList("hologram.text")) {
-            DHAPI.addHologramLine(holo, line);
+            // Kinda messy but this enabled new lines from placeholders to be used which
+            // is helpful for showing leaderboard and multi line descriptions
+            if (line.contains("%communityquests")) {
+                String placeholderValue = PlaceholderAPI.setPlaceholders(null, line);
+                String[] lines = placeholderValue.split("\\\\n|\\r?\\n");
+                for (String l : lines) {
+                    DHAPI.addHologramLine(holo, l);
+                }
+            } else {
+                DHAPI.addHologramLine(holo, line);
+            }
         }
     }
 
     public void removeHologram() {
+        stopRefreshTimer();
         if (holo != null) {
             holo.delete();
         }
     }
 
+    @EventHandler
     public void onPlayerClick(HologramClickEvent event) {
         if (event.getClick().equals(ClickType.RIGHT)) {
-            new ViewMenu(plugin, event.getPlayer()).open();
+            Bukkit.getScheduler().runTask(plugin, () -> {
+                new ViewMenu(plugin, event.getPlayer()).open();
+            });
         }
     }
 }

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/players/BasePlayerComponent.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/players/BasePlayerComponent.java
@@ -15,6 +15,9 @@ import org.json.simple.JSONObject;
 
 import com.google.gson.Gson;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,17 +25,16 @@ import java.util.TreeMap;
 import java.util.UUID;
 
 public class BasePlayerComponent implements Colorization {
-
+    @Setter
+    @Getter
     private static int leaderBoardSize = 5;
 
     private final Map<UUID, PlayerData> playerMap;
-    private final ArrayList<Reward> rewardsList;
     private final Map<String, ArrayList<Reward>> rankedRewards;
     private final int rewardsLimit;
 
     public BasePlayerComponent(ArrayList<Reward> rewardsList, int rewardLimit,
             Map<String, ArrayList<Reward>> rankedRewards) {
-        this.rewardsList = rewardsList;
         this.playerMap = new TreeMap<>();
         this.rewardsLimit = rewardLimit;
         this.rankedRewards = rankedRewards;
@@ -40,14 +42,9 @@ public class BasePlayerComponent implements Colorization {
 
     public BasePlayerComponent(ArrayList<Reward> rewardsList, Map<UUID, PlayerData> map, int rewardLimit,
             Map<String, ArrayList<Reward>> rankedRewards) {
-        this.rewardsList = rewardsList;
         this.playerMap = map;
         this.rewardsLimit = rewardLimit;
         this.rankedRewards = rankedRewards;
-    }
-
-    public static void setLeaderBoardSize(int size) {
-        leaderBoardSize = size;
     }
 
     public void savePlayerAction(Player player, double count, Integer objectiveId) {
@@ -61,14 +58,11 @@ public class BasePlayerComponent implements Colorization {
         }
     }
 
-    public void sendLeaderString() {
-        if (leaderBoardSize <= 0) {
-            return;
+    public String getLeaderString() {
+        if (leaderBoardSize <= 0 || this.playerMap.size() < 1) {
+            return "";
         }
 
-        if (this.playerMap.size() < 1) {
-            return;
-        }
         ServerQuests plugin = JavaPlugin.getPlugin(ServerQuests.class);
         StringBuilder result = new StringBuilder(plugin.messages().string("topContributorsTitle"));
         TreeMap<UUID, PlayerData> map = new TreeMap<>(new SortByContributions(this.playerMap));
@@ -89,7 +83,11 @@ public class BasePlayerComponent implements Colorization {
 
             count++;
         }
-        Bukkit.getServer().broadcastMessage(color(result.toString()));
+        return color(result.toString());
+    }
+
+    public void sendLeaderString() {
+        Bukkit.getServer().broadcastMessage(getLeaderString());
     }
 
     public PlayerData getTopPlayer() {

--- a/src/main/java/me/wonka01/placeholders/CommunityQuestsPlaceholders.java
+++ b/src/main/java/me/wonka01/placeholders/CommunityQuestsPlaceholders.java
@@ -48,9 +48,10 @@ public class CommunityQuestsPlaceholders extends PlaceholderExpansion implements
     public String onRequest(OfflinePlayer player, String identifier) {
 
         String questId = identifier.substring(identifier.lastIndexOf("_") + 1);
+
         List<QuestController> quests = ActiveQuests.getActiveQuestsInstance().getActiveQuestsList();
         String[] keywords = { "goal", "complete", "remaining", "name", "description", "you", "contribution",
-                "progressbar", "you" };
+                "progressbar", "top", "all" };
 
         QuestController controller = null;
         QuestData questData = null;

--- a/src/main/java/me/wonka01/placeholders/CommunityQuestsPlaceholders.java
+++ b/src/main/java/me/wonka01/placeholders/CommunityQuestsPlaceholders.java
@@ -144,9 +144,14 @@ public class CommunityQuestsPlaceholders extends PlaceholderExpansion implements
             return color(questData.getObjectives().get(index).getDescription());
         }
 
+        // Show top playerz
+        // %communityquests_top_all_questId%
+        if (identifier.startsWith("top_all")) {
+            return controller.getPlayerComponent().getLeaderString();
+        }
+
         // %communityquests_top_1_name_questId%
         // %communityquests_top_1_contribution_questId%
-
         if (identifier.startsWith("top")) {
             int index = extractIndex(identifier.replace(questId, "")) - 1;
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,46 +5,50 @@ questLimit: 5
 # If this is set to 0 then the leader board message will be omitted.
 leaderBoardSize: 5
 
-# See color options here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarColor.html
-barColor: "GREEN"
-
-# See style options here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarStyle.html
-barStyle: "SOLID"
-
 disableBossBar: false
 
-# If enabled, blockbreak quests will not be able to break the same item multiple
+# Material used in the donate quest menu.
+donateMenuItem: EMERALD
+
+# If true, blockbreak quests will not be able to break the same item multiple
 # times in a row.
 disableDuplicateBreaks: false
 
-# If enabled, blockplace quests will not be able to place the same item multiple
+barColor: "GREEN"
+
+# If true, blockplace quests will not be able to place the same item multiple
 # times in a row.
 disableDuplicatePlaces: false
 
-# Material used in the donate quest menu.
-donateMenuItem: OBSIDIAN
-
 ## configure the location and text of a hologram that displays quest information
 hologram:
+    # set to 0 or omit refresh-interval if you don't want it to refresh. Refresh is needed for dynamic placeholders
+    refresh-interval: 60
     enabled: true
     location:
         world: world
-        x: 0
-        y: 0
-        z: 0
+        x: -78
+        y: 67
+        z: 51
     text:
-        - "&6&lQuests"
+        - "<#B22AFE>&l&nCommunity Quests</#ff8157>"
         - "&f&lRight click to view quests"
+        - "%communityquests_name%"
+        - "%communityquests_description%"
+        - "%communityquests_top_all%"
 
 Quests:
     TestQuest: # Quest identifier can be whatever you'd like as long as it's unique
         displayName: "&cZombie and Pig Slayer"
         displayItem: ZOMBIE_HEAD # optional parameter to set the item used in GUIs for a given quest
+        # See color options here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarColor.html
+        barColor: "GREEN"
+        barStyle: "SEGMENTED_20"
         worlds: # this parameter is optional, if included the quest will only occur in the specified worlds
             - world
         objectives: # at least one objective is required, each quest can have infinite objectives
             - type: mobkill ## required, see type list for available types
-              goal: 10 # The goal is the amount of the task to be completed
+              dynamicGoal: "%server_online%"
               entities: # This is an optional parameter, if it doesn't exist the quest will count ALL mob kills. entity reference: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/entity/EntityType.html
                   - Zombie
                   - Pig
@@ -52,10 +56,10 @@ Quests:
               description: "Zombies & Pigs" # A short description of the objective used in the GUI
             - type: mobkill
               goal: 5
-              entities:
+              customMobNames:
                   - Skeleton
               description: Skeletons
-        description: Kill 100 zombies and pigs!
+        description: "Kill 100 zombies and pigs! \nKill 50 skeletons!"
         questDuration: 1d # The quest will last for 1 day or until the goal is reached, whichever comes first
         rewards:
             rankedRewards:
@@ -77,3 +81,261 @@ Quests:
                         - material: stone_sword
                           amount: 1
                           displayName: "&8Stone Sword"
+    Egg:
+        displayName: "&6Eggcellent"
+        displayItem: EGG
+        questDuration: 7d
+        barColor: "WHITE"
+        barStyle: "SEGMENTED_20"
+        objectives:
+            - type: donate
+              materials:
+                  - EGG
+        description: H1 needs some cake, you can get some eggs!
+        rewards:
+            items:
+                - material: CHICKEN_SPAWN_EGG
+                  amount: 1
+    MoveIt:
+        displayName: "&6Movement Quest"
+        displayItem: DIAMOND_BOOTS
+        questDuration: 7d
+        barColor: "WHITE"
+        barStyle: "SEGMENTED_20"
+        objectives:
+            - type: movement
+        description: Just keep on running until your shoes fall off!
+        rewards:
+            items:
+                - material: CHICKEN_SPAWN_EGG
+                  amount: 1
+    FishFrenzy:
+        displayName: "&9&lFishing Frenzy"
+        questDuration: 30m
+        barColor: "BLUE"
+        barStyle: "SOLID"
+        objectives:
+            - type: catchfish
+              goal: 8
+              entities:
+                  - Cod
+              description: "&9&lCod"
+            - type: catchfish
+              goal: 4
+              entities:
+                  - Salmon
+              description: "&9&lSalmon"
+        description: "&fCatch 8 cod and 4 salmon as fast as you can!"
+        displayItem: fishing_rod
+        rewards:
+            rankedRewards:
+                "1": # The key is the rank of the player so this reward will be given to the player who contributed the most
+                    experience: 100
+                    items:
+                        - material: diamond_sword
+                          amount: 1
+                          displayName: "&bPowerful Diamond Sword"
+                "2":
+                    experience: 50
+                    items:
+                        - material: iron_sword
+                          amount: 1
+                          displayName: "&7Iron Sword"
+                "*": # This is a wildcard, this reward will apply to all other players who participated in the quest and didn't get a ranked reward
+                    experience: 25
+                    items:
+                        - material: stone_sword
+                          amount: 1
+                          displayName: "&8Stone Sword"
+    CarrotQuest:
+        displayName: "&6&lCarrot King"
+        objectives:
+            - type: blockbreak
+              goal: 25
+              materials:
+                  - carrots
+              description: "&6&lCarrots"
+            - type: blockbreak
+              goal: 10
+              materials:
+                  - wheat
+              description: "&6&lWheat"
+        description: "&fPlant some carrots"
+        displayItem: CARROT
+        rewards:
+            rankedRewards:
+                "1": # The key is the rank of the player so this reward will be given to the player who contributed the most
+                    experience: 100
+                    items:
+                        - material: diamond_sword
+                          amount: 1
+                          displayName: "&bPowerful Diamond Sword"
+                "2":
+                    experience: 50
+                    items:
+                        - material: iron_sword
+                          amount: 1
+                          displayName: "&7Iron Sword"
+                "*": # This is a wildcard, this reward will apply to all other players who participated in the quest and didn't get a ranked reward
+                    experience: 25
+                    items:
+                        - material: stone_sword
+                          amount: 1
+                          displayName: "&8Stone Sword"
+    GuiQuest:
+        displayName: "&a&lPotato Diamond Quest"
+        objectives:
+            - type: donate
+              goal: 60
+              materials:
+                  - POTATO
+              description: "&l&aPotatoes"
+            - type: donate
+              goal: 20
+              materials:
+                  - DIAMOND
+              description: "&l&aDiamonds"
+        description: "&fDonate 60 potatoes and 20 diamonds with /cq donate!"
+        rewards:
+            rankedRewards:
+                "1": # The key is the rank of the player
+                    experience: 100
+                    commands:
+                        - "give %player% diamond_sword 1"
+                    items:
+                        - material: DIAMOND_SWORD
+                          amount: 1
+                          displayName: "&bPowerful Diamond Sword"
+                "2":
+                    experience: 50
+                    items:
+                        - material: iron_sword
+                          amount: 1
+                          displayName: "&7Iron Sword"
+                "*": # This is a wildcard, it will apply to all other players
+                    experience: 25
+                    items:
+                        - material: stone_sword
+                          amount: 1
+                          displayName: "&8Stone Sword"
+    PlantTree:
+        displayName: "&a&lSave the Planet"
+        description: "&fPlant 10 oak or acacia trees and break 10 logs!"
+        objectives:
+            - type: blockplace
+              materials:
+                  - OAK_SAPLING
+                  - ACACIA_SAPLING
+              description: "&fPlant trees"
+              goal: 10
+            - type: blockbreak
+              materials:
+                  - OAK_LOG
+                  - ACACIA_LOG
+                  - FIRE
+              goal: 10
+              description: "&fChop trees"
+        rewards:
+            experience: 100
+            items:
+                - material: EMERALD
+                  amount: 64
+                  displayName: "&cEmerald"
+    EatFood:
+        displayName: "&l&aEat Food"
+        objectives:
+            - type: consumeitem
+              goal: 25
+              description: "&fFood consumed"
+              materials:
+                  - APPLE
+                  - POTATO
+                  - Mushroom_Stew
+        description: "&fEat 25 apples, potatoes, or mushroom stew!"
+        rewards:
+            experience: 100
+            items:
+                - material: EMERALD
+                  amount: 64
+                  displayName: "&cEmerald"
+    CraftSwords:
+        displayName: "&l&aSwords and Sticks!"
+        description: "&fCraft 10 swords and 10 sticks!"
+        rewards:
+            experience: 100
+        objectives:
+            - type: craftitem
+              materials:
+                  - DIAMOND_SWORD
+                  - IRON_SWORD
+              description: "&bDiamond swords"
+              goal: 10
+            - type: craftItem
+              materials:
+                  - STICK
+              goal: 10
+              description: "&bStick"
+    ExpQuest: # Quest identifier can be whatever you'd like as long as it's unique
+        displayName: "&c&lGet that EXP"
+        objectives:
+            - type: experience
+              goal: 10000
+              description: "EXP"
+        description: "&fGet lots of experience"
+        rewards:
+            experience: 10000
+            items:
+                - material: DIAMOND_SWORD
+                  amount: 1
+                  displayName: "&bPowerful Diamond Sword"
+    MythicQuest:
+        displayName: "&c&lKill mythic mobs"
+        objective:
+            - type: mythicmob
+              goal: 4
+              description: "Spiderz"
+              entities:
+                  - CAVE_SPIDER
+        description: "&c&lKill 4 Cave Spiders!"
+        rewards:
+            experience: 10000
+            items:
+                - material: DIAMOND_SWORD
+                  amount: 1
+                  displayName: "&bPowerful Diamond Sword"
+    BreakStuff:
+        displayName: "Just break stuff"
+        objectives:
+            - type: blockbreak
+              goal: 100
+              description: "Broken blox"
+        description: "&fbreak anythingggggg"
+        rewards:
+            experience: 10000
+            commands:
+                - 'give %player% diamond_sword 1 0 {display:{Name:"{\"text\":\"Powerful Diamond Sword\",\"color\":\"aqua\"}"},ench:[{id:16,lvl:5}]}'
+    CarvePumpkin:
+        displayName: "Carve a pumpkin"
+        objectives:
+            - type: carvepumpkin
+              goal: 10
+              description: "pumpkinz"
+        description: "Lets carve some pumpkins for Halloween!"
+        rewards:
+            experience: 10000
+        commands:
+            - 'give %player% diamond_sword 1 0 {display:{Name:"{\"text\":\"Powerful Diamond Sword\",\"color\":\"aqua\"}"},Enchantments:[{id:sharpness,lvl:5}]}'
+    Cane:
+        displayName: "&6Sugar it up"
+        displayItem: SUGAR_CANE
+        questDuration: 7d
+        objectives:
+            - type: blockbreak
+              goal: 10
+              materials:
+                  - SUGAR_CANE
+              description: "I need some Sugar!"
+        rewards:
+            items:
+                - material: GRASS_BLOCK
+                  amount: 16

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -8,6 +8,9 @@ leaderBoardSize: 5
 # See color options here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarColor.html
 barColor: "GREEN"
 
+# See style options here: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/boss/BarStyle.html
+barStyle: "SOLID"
+
 disableBossBar: false
 
 # If enabled, blockbreak quests will not be able to break the same item multiple
@@ -20,6 +23,18 @@ disableDuplicatePlaces: false
 
 # Material used in the donate quest menu.
 donateMenuItem: OBSIDIAN
+
+## configure the location and text of a hologram that displays quest information
+hologram:
+    enabled: true
+    location:
+        world: world
+        x: 0
+        y: 0
+        z: 0
+    text:
+        - "&6&lQuests"
+        - "&f&lRight click to view quests"
 
 Quests:
     TestQuest: # Quest identifier can be whatever you'd like as long as it's unique

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -13,6 +13,7 @@ softdepend:
     - Vault
     - PlaceholderAPI
     - MythicMobs
+    - DecentHolograms
 
 permissions:
     communityquests.start:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -55,3 +55,6 @@ permissions:
     communityquests.clearrewards:
         description: Clear rewards from all quests
         default: op
+    communityquests.schedule:
+        description: Schedule quests
+        default: op

--- a/src/main/resources/schedules.yml
+++ b/src/main/resources/schedules.yml
@@ -1,0 +1,9 @@
+# Example scheduled quest
+daily_quest_example:
+    # quest to use, if you set the id value to random it will randomly select from all quests
+    # defined from the config
+    questId: TestQuest
+    mode: coop
+    time: "16:00"
+    scheduleType: DAILY
+    enabled: false


### PR DESCRIPTION
- added hologram support (see docs for setup)
- scheduler command and config for running quests on a schedule
- The config for both of these may change as I gather feedback, so let me know what you think!
- added dyanmicGoal option so placeholders can be used to set the goal of a quest (for example goal can be based on number of players online when it starts.
- added new quest type for blocks traveled
- respect newline character /n in the quest description !
- new placeholder for quest leaderboard
- new barStyle config option to change the style of the bossbar.
- moved barColor to quests, so each individual quest can have it's own color
- leaderboard size config value now also impacts leaderboard on /cq view
- fixed bug with donate quests that did not have a goal specified
