### PR TITLE
Scheduler bug and add random option

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,8 @@ Basic command structure:
 
 -   Daily Quest: `/cq schedule mining coop 14:30 DAILY add`  
     Starts the "mining" quest every day at 2:30 PM
+-   Random Quest: `/cq schedule random coop 14:30 DAILY add`
+    Starts a random quest every day at 2:30 PM
 -   Weekly Quest: `/cq schedule fishing coop 09:00 WEEKLY add MONDAY`  
     Starts the "fishing" quest every Monday at 9:00 AM
 -   Custom Interval: `/cq schedule boss comp 20:00 CUSTOM_DAYS add 3`  

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Pass in a command to be run if a quest fails, this will only be run if a quest h
 ### worlds (optional)
 
 Use this parameter to restrict quests to specific worlds. All worlds in the list will be able to participate in quests. When no value
-is provided for worlds then the quest will be enabled in every world.
+is provided for worlds the quest will be enabled in every world.
 
 ### disableDuplicateBreaks
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.wonka01</groupId>
     <artifactId>CommunityQuests</artifactId>
-    <version>2.11.3</version>
+    <version>2.11.4</version>
 
     <contributors>
         <contributor>

--- a/src/main/java/me/knighthat/apis/menus/Menu.java
+++ b/src/main/java/me/knighthat/apis/menus/Menu.java
@@ -93,7 +93,6 @@ public abstract class Menu implements InventoryHolder, Colorization {
     }
 
     protected @NonNull List<String> getLoreFromData(@NonNull QuestData data) {
-
         List<String> lore = new ArrayList<>();
         String[] description = data.getDescriptionArr();
         for (String s : description) {

--- a/src/main/java/me/wonka01/ServerQuests/commands/QuestScheduler.java
+++ b/src/main/java/me/wonka01/ServerQuests/commands/QuestScheduler.java
@@ -95,7 +95,7 @@ public class QuestScheduler extends PluginCommand {
         String action = args[5].toLowerCase();
 
         // check quest library to see if id exists
-        if (!plugin.config().getQuestLibrary().containsQuest(questId) || questId.equalsIgnoreCase("random")) {
+        if (!plugin.config().getQuestLibrary().containsQuest(questId) && !questId.equalsIgnoreCase("random")) {
             sender.sendMessage("§cQuest with ID " + questId + " does not exist!");
             return;
         }
@@ -260,8 +260,14 @@ public class QuestScheduler extends PluginCommand {
         BukkitRunnable task = new BukkitRunnable() {
             @Override
             public void run() {
-                Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "cq start " + questId + " " + mode);
-                plugin.getLogger().info("Scheduled quest " + questId + " executed in " + mode + " mode");
+                if (questId.equalsIgnoreCase("random")) {
+                    String random = plugin.config().getQuestLibrary().getRandomQuest();
+                    Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "cq start " + random + " " + mode);
+                    plugin.getLogger().info("Scheduled random quest executed in " + mode + " mode");
+                } else {
+                    Bukkit.dispatchCommand(Bukkit.getConsoleSender(), "cq start " + questId + " " + mode);
+                    plugin.getLogger().info("Scheduled quest " + questId + " executed in " + mode + " mode");
+                }
             }
         };
 

--- a/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/JsonQuestSave.java
@@ -146,17 +146,7 @@ public class JsonQuestSave {
                     JSONObject obj = pIterator.next();
                     String key = (String) obj.keySet().iterator().next();
                     UUID uuid = UUID.fromString(key);
-                    String playerName = Bukkit.getServer().getOfflinePlayer(uuid).getName();
-                    if (playerName == null) {
-                        ArrayList<String> randomNames = new ArrayList<>();
-                        randomNames.add("NotSoJuicyJuan");
-                        randomNames.add("Notch");
-                        randomNames.add("Availer");
-                        randomNames.add("Vaquxine");
-                        randomNames.add("Taco");
-                        randomNames.add("ish");
-                        playerName = randomNames.get((int) (Math.random() * randomNames.size()));
-                    }
+                    String playerName = (String) obj.get("name");
                     Gson gson = new Gson();
 
                     // Define the type of the HashMap

--- a/src/main/java/me/wonka01/ServerQuests/configuration/QuestLibrary.java
+++ b/src/main/java/me/wonka01/ServerQuests/configuration/QuestLibrary.java
@@ -51,6 +51,15 @@ public class QuestLibrary {
         questList = map;
     }
 
+    public String getRandomQuest() {
+        List<String> keys = new ArrayList<>(questList.keySet());
+        if (keys.isEmpty()) {
+            return null;
+        }
+        Random random = new Random();
+        return keys.get(random.nextInt(keys.size()));
+    }
+
     private QuestModel loadQuestFromConfig(ConfigurationSection section) {
         String questId = section.getName();
         String displayName = section.getString("displayName");

--- a/src/main/java/me/wonka01/ServerQuests/gui/ViewMenu.java
+++ b/src/main/java/me/wonka01/ServerQuests/gui/ViewMenu.java
@@ -11,7 +11,9 @@ import me.wonka01.ServerQuests.questcomponents.QuestData;
 import me.wonka01.ServerQuests.questcomponents.players.BasePlayerComponent;
 import me.wonka01.ServerQuests.questcomponents.players.PlayerData;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryCloseEvent;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.ArrayList;
@@ -19,8 +21,11 @@ import java.util.List;
 
 public class ViewMenu extends Menu {
 
+    private int schedulerId;
+
     public ViewMenu(ServerQuests plugin, @NonNull Player owner) {
         super(plugin, owner, "viewQuests", 36);
+        this.schedulerId = createScheduler();
     }
 
     @Override
@@ -68,6 +73,21 @@ public class ViewMenu extends Menu {
             getObjectivePlayerProgress(data.getObjectives(), lore, getOwner(), (CompetitiveQuestData) data);
         }
         return super.createItemStack(data.getDisplayItem(), data.getDisplayName(), lore);
+    }
+
+    private int createScheduler() {
+        // refresh every 1 second
+        return Bukkit.getScheduler().scheduleSyncRepeatingTask(getPlugin(), this::refreshMenu, 0L, 20L);
+    }
+
+    private void refreshMenu() {
+        getInventory().clear();
+        setContents();
+    }
+
+    @Override
+    protected void onClose(InventoryCloseEvent event) {
+        Bukkit.getScheduler().cancelTask(schedulerId);
     }
 
     private void getTopPlayerString(QuestController controller, List<String> lore) {

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/bossbar/QuestBar.java
@@ -15,7 +15,6 @@ public class QuestBar implements Colorization {
 
     public QuestBar(@NonNull String name, @NonNull String color, @NonNull BarStyle style) {
         this.barColor = getBarColor(color);
-        Bukkit.broadcastMessage("Actually adding with color " + this.barColor.toString());
         bar = Bukkit.createBossBar(color(name), this.barColor, style);
         bar.setVisible(true);
         bar.setProgress(0.0);

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/players/BasePlayerComponent.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/players/BasePlayerComponent.java
@@ -150,6 +150,7 @@ public class BasePlayerComponent implements Colorization {
             Gson gson = new Gson();
             String jsonString = gson.toJson(playerMap.get(key).getObjectiveContributions());
             jsonObject.put(key.toString(), jsonString);
+            jsonObject.put("name", playerMap.get(key).getName());
             jArray.add(jsonObject);
         }
         return jArray;

--- a/src/main/java/me/wonka01/ServerQuests/questcomponents/schedulers/QuestTimer.java
+++ b/src/main/java/me/wonka01/ServerQuests/questcomponents/schedulers/QuestTimer.java
@@ -9,9 +9,9 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.bukkit.scheduler.BukkitTask;
 
 public class QuestTimer {
-    // checks every 2 seconds to see if the quest is complete (TODO make this
+    // checks every 1 seconds to see if the quest is complete (TODO make this
     // configurable)
-    private final long INTERVAL = 2L;
+    private final long INTERVAL = 1L;
 
     private QuestController controller;
     private BukkitTask task;


### PR DESCRIPTION
- the /cq view menu is now updated in real time 
- added a random option for the scheduler, use random instead of a questId and a random quest will be selected from your config
- fixed the duration timer to run every second (was running every two seconds)
- names are now saved so it always uses the display name
- fixed issue with scheduler when reloading the plugin